### PR TITLE
ASE training problems

### DIFF
--- a/phys_anim/agents/infomax.py
+++ b/phys_anim/agents/infomax.py
@@ -55,6 +55,7 @@ class InfoMax(AMP):
         )
 
         self.experience_buffer.register_key("mi_rewards")  # mi = mutual information
+        self.experience_buffer.register_key("latents", shape=(sum(self.config.infomax_parameters.latent_dim),))
 
     def update_latents(self):
         self.latent_reset_steps.advance()
@@ -128,6 +129,7 @@ class InfoMax(AMP):
         actor_state = super().post_env_step(actor_state)
         self.update_latents()
         actor_state["latents"] = self.latents
+        self.experience_buffer.update_data("latents", actor_state["step"],actor_state["latents"])
         return actor_state
 
     def post_eval_env_step(self, actor_state):
@@ -135,6 +137,16 @@ class InfoMax(AMP):
         actor_state["latents"] = self.latents
         actor_state = super().post_eval_env_step(actor_state)
         return actor_state
+
+    def create_actor_args(self, actor_state):
+        actor_args = super().create_actor_args(actor_state)
+        actor_args['latents'] = actor_state['latents']
+        return actor_args
+
+    def create_critic_args(self, actor_state):
+        critic_args = super().create_critic_args(actor_state)
+        critic_args['latents'] = actor_state['latents']
+        return critic_args
 
     def calculate_extra_reward(self):
         rew = super().calculate_extra_reward()


### PR DESCRIPTION
Steps to reproduce:
1. With current main branch. I was using this command: `phys_anim/train_agent.py +exp=infomax +robot=sword_and_shield +backbone=isaacgym motion_file=phys_anim/data/motions/amp_sword_and_shield_humanoid_walk.npy`
  1.1. For some reason, I couldn't use `+exp=ase`, as you specified in readme. My version of hydra-core is 1.3.2.

This gave me:
```
File ".../phys_anim/agents/models/mlp.py", line 121, in forward
    key_obs = {"obs": input_dict[key]}
KeyError: 'latents'
```

To fix this, I've overridden `create_actor_args` and `create_critic_args` in `InfoMax` to add latents in `*_inputs`.

But this:
```
File ".../phys_anim/agents/infomax.py", line 155, in calculate_extra_reward
    latents = self.experience_buffer.latents
```

To fix this, I've registered latents in experience buffer, and updating it in `post_env_step`.

Then training continues without errors.

That is kinda ad hoc approach. So I'm seeking for approval of such fix.