### PR TITLE
fix python > 3.10

### DIFF
--- a/protomotions/simulator/base_simulator/config.py
+++ b/protomotions/simulator/base_simulator/config.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal, Tuple, List, Dict, Optional, Any, Type, TypeVar
 import torch
 from enum import Enum
@@ -229,7 +229,7 @@ class RobotConfig(ConfigBuilder):
     
     # Optional with default
     contact_pairs_multiplier: int = 16
-    control: ControlConfig = ControlConfig()
+    control: ControlConfig = field(default_factory=ControlConfig)
 
     def __post_init__(self):
         """Compute derived fields after initialization."""

--- a/requirements_genesis.txt
+++ b/requirements_genesis.txt
@@ -14,7 +14,7 @@ typer>=0.6.1
 transformers>=4.20.1
 matplotlib
 easydict
-wandb==0.15.12
+wandb==0.19.8
 tensorboardX
 sentry-sdk==1.9.10
 hydra-core==1.3.2

--- a/requirements_genesis.txt
+++ b/requirements_genesis.txt
@@ -1,7 +1,7 @@
 genesis-world
 wheel
-torch==2.5.0
-lightning==2.5.0.post0
+torch>=2.5.0
+lightning>=2.5.0.post0
 numpy>=1.21.1
 termcolor>=1.1.0
 scikit-image
@@ -14,14 +14,14 @@ typer>=0.6.1
 transformers>=4.20.1
 matplotlib
 easydict
-wandb==0.19.8
+wandb>=0.19.8
 tensorboardX
 sentry-sdk==1.9.10
 hydra-core==1.3.2
-PyOpenGL==3.1.4
+PyOpenGL>=3.1.4
 # pydantic==1.10.9
 moviepy
-open3d==0.19.0
+open3d>=0.19.0
 
 # export __NV_PRIME_RENDER_OFFLOAD=1
 # export __GLX_VENDOR_LIBRARY_NAME=nvidia

--- a/requirements_isaacgym.txt
+++ b/requirements_isaacgym.txt
@@ -9,7 +9,7 @@ setuptools==69.5.1
 rich
 smpl_sim @ git+https://github.com/ZhengyiLuo/SMPLSim.git@master
 typer>=0.6.1
-wandb>=0.13.4
+wandb>=0.19.8
 transformers>=4.20.1
 hydra-core>=1.2.0
 matplotlib

--- a/requirements_isaaclab.txt
+++ b/requirements_isaaclab.txt
@@ -13,7 +13,7 @@ typer>=0.6.1
 transformers>=4.20.1
 matplotlib
 easydict
-wandb==0.15.12
+wandb==0.19.8
 sentry-sdk==1.9.10
 hydra-core==1.3.2
 pydantic==1.10.9


### PR DESCRIPTION
This pull request includes updates to the `wandb` package versions across multiple requirements files. The most important changes are the version updates in `requirements_genesis.txt`, `requirements_isaacgym.txt`, and `requirements_isaaclab.txt`.

Version updates:

* [`requirements_genesis.txt`](diffhunk://#diff-4435f0758e92efe3f0fd24c3a64b9a52b370e82b4db533567576e70551bc03b8L17-R17): Updated `wandb` from `0.15.12` to `0.19.8`.
* [`requirements_isaacgym.txt`](diffhunk://#diff-d36cca54df61a0458553ec56118fc86c7ca2839e2ea3260cee0ae8f59d60b259L12-R12): Updated `wandb` from `>=0.13.4` to `>=0.19.8`.
* [`requirements_isaaclab.txt`](diffhunk://#diff-0ee6160c5651b15eb459d32a119067d31b6fa41d5f60467de781f074fbbe9141L16-R16): Updated `wandb` from `0.15.12` to `0.19.8`.

old wandb versions use pathtools that it is deprecated