### PR TITLE
make joint_axis optional (it breaks several examples)

### DIFF
--- a/examples/benchmark/genesis_bench.py
+++ b/examples/benchmark/genesis_bench.py
@@ -28,6 +28,7 @@ robot_config = RobotConfig(
     dof_body_ids=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
     dof_obs_size=114,  # 19 joints * 6 (pos, vel, etc.)
     number_of_actions=19,
+    joint_axis=[],
     self_obs_max_coords_size=373,
     left_foot_name="left_foot_link",
     right_foot_name="right_foot_link",

--- a/protomotions/simulator/base_simulator/config.py
+++ b/protomotions/simulator/base_simulator/config.py
@@ -200,7 +200,6 @@ class RobotConfig(ConfigBuilder):
     dof_names: List[str]
     dof_body_ids: List[int]
     dof_obs_size: int
-    joint_axis: List[str]
     number_of_actions: int
     self_obs_max_coords_size: int
     left_foot_name: str
@@ -218,7 +217,8 @@ class RobotConfig(ConfigBuilder):
     contact_bodies: Optional[List[str]] = None  # Defaults to body_names
     trackable_bodies_subset: Optional[List[str]] = None  # Defaults to body_names
     self_obs_size: Optional[int] = None  # Defaults to self_obs_max_coords_size
-    
+    joint_axis: List[str] = None 
+ 
     # Optional fields
     dof_effort_limits: Optional[List[float]] = None
     dof_vel_limits: Optional[List[float]] = None


### PR DESCRIPTION
Currently, various examples are broken. Can we make joint_axis optional, until things are fixed?
(those examples run without it, so it looks joint_axis was optional anyway?)
