### PR TITLE
Addressing issue #90 (https://github.com/NVlabs/ProtoMotions/issues/90)

### DIFF
--- a/protomotions/agents/masked_mimic/agent.py
+++ b/protomotions/agents/masked_mimic/agent.py
@@ -88,7 +88,7 @@ class MaskedMimic(PPO):
             checkpoint_path = self.config.expert_model_path + "/score_based.ckpt"
             if not Path(checkpoint_path).exists():
                 checkpoint_path = self.config.expert_model_path + "/last.ckpt"
-            pre_trained_expert = torch.load(checkpoint_path)
+            pre_trained_expert = torch.load(checkpoint_path, map_location='cpu')
 
             self.expert_model_config = OmegaConf.load(
                 Path(self.config.expert_model_path) / "config.yaml"
@@ -108,10 +108,12 @@ class MaskedMimic(PPO):
             expert_model: PPOModel = instantiate(
                 self.expert_model_config.agent.config.model
             )
+            
+            # load parameters before setting up the model
+            expert_model.load_state_dict(pre_trained_expert["model"])
+
             self.expert_model = self.fabric.setup(expert_model)
             self.expert_model.mark_forward_method("act")
-
-            self.expert_model.load_state_dict(pre_trained_expert["model"])
             for param in self.expert_model.parameters():
                 param.requires_grad = False
             self.expert_model.eval()  # Just incase

--- a/protomotions/agents/masked_mimic/agent_no_vae.py
+++ b/protomotions/agents/masked_mimic/agent_no_vae.py
@@ -77,7 +77,7 @@ class MaskedMimicNoVae(PPO):
             checkpoint_path = self.config.expert_model_path + "/score_based.ckpt"
             if not Path(checkpoint_path).exists():
                 checkpoint_path = self.config.expert_model_path + "/last.ckpt"
-            pre_trained_expert = torch.load(checkpoint_path)
+            pre_trained_expert = torch.load(checkpoint_path, map_location='cpu')
 
             self.expert_model_config = OmegaConf.load(
                 Path(self.config.expert_model_path) / "config.yaml"
@@ -97,10 +97,13 @@ class MaskedMimicNoVae(PPO):
             expert_model: PPOModel = instantiate(
                 self.expert_model_config.agent.config.model
             )
+            
+            # load parameters before setting up the model
+            expert_model.load_state_dict(pre_trained_expert["model"])
+
             self.expert_model = self.fabric.setup(expert_model)
             self.expert_model.mark_forward_method("act")
 
-            self.expert_model.load_state_dict(pre_trained_expert["model"])
             for param in self.expert_model.parameters():
                 param.requires_grad = False
             self.expert_model.eval()  # Just incase

--- a/protomotions/agents/masked_mimic/agent_no_vae.py
+++ b/protomotions/agents/masked_mimic/agent_no_vae.py
@@ -77,8 +77,7 @@ class MaskedMimicNoVae(PPO):
             checkpoint_path = self.config.expert_model_path + "/score_based.ckpt"
             if not Path(checkpoint_path).exists():
                 checkpoint_path = self.config.expert_model_path + "/last.ckpt"
-            pre_trained_expert = torch.load(checkpoint_path, map_location='cpu')
-
+            
             self.expert_model_config = OmegaConf.load(
                 Path(self.config.expert_model_path) / "config.yaml"
             )
@@ -97,13 +96,12 @@ class MaskedMimicNoVae(PPO):
             expert_model: PPOModel = instantiate(
                 self.expert_model_config.agent.config.model
             )
-            
-            # load parameters before setting up the model
-            expert_model.load_state_dict(pre_trained_expert["model"])
-
             self.expert_model = self.fabric.setup(expert_model)
             self.expert_model.mark_forward_method("act")
 
+            # loading should be done after fabric.setup to ensure the model is on the correct fabric.device
+            pre_trained_expert = torch.load(checkpoint_path, map_location=self.fabric.device) 
+            self.expert_model.load_state_dict(pre_trained_expert["model"])
             for param in self.expert_model.parameters():
                 param.requires_grad = False
             self.expert_model.eval()  # Just incase


### PR DESCRIPTION
When using multiple GPUs (e.g., 1 node with 4 GPUs), the expert model is wrapped with Fabric **before** loading the checkpoint. This causes the model weights to be loaded only on rank 0 and not broadcasted to other GPUs, resulting in incorrect or uninitialized expert behavior during training.

The fix is to first load the model and its weights, then wrap it using `fabric.setup`. This ensures the expert model is correctly initialized and broadcasted across all GPUs.