### PR TITLE
Support macOS for Genesis

### DIFF
--- a/protomotions/agents/ppo/agent.py
+++ b/protomotions/agents/ppo/agent.py
@@ -179,9 +179,10 @@ class PPO:
 
         # Check if new high score flag is consistent across devices.
         gathered_high_score = self.fabric.all_gather(new_high_score)
-        assert all(
-            [x == gathered_high_score[0] for x in gathered_high_score]
-        ), "New high score flag should be the same across all ranks."
+        if gathered_high_score.dim() != 0:
+            assert all(
+                [x == gathered_high_score[0] for x in gathered_high_score]
+            ), "New high score flag should be the same across all ranks."
 
         if new_high_score:
             score_based_name = "score_based.ckpt"

--- a/protomotions/envs/base_env/env_utils/terrains/terrain.py
+++ b/protomotions/envs/base_env/env_utils/terrains/terrain.py
@@ -362,6 +362,7 @@ class Terrain:
             ),
             device=self.device,
             requires_grad=False,
+            dtype=torch.float
         )
         x = torch.tensor(
             np.linspace(
@@ -371,6 +372,7 @@ class Terrain:
             ),
             device=self.device,
             requires_grad=False,
+            dtype=torch.float
         )
         grid_x, grid_y = torch.meshgrid(x, y)
 

--- a/protomotions/simulator/genesis/simulator.py
+++ b/protomotions/simulator/genesis/simulator.py
@@ -43,7 +43,7 @@ class GenesisSimulator(Simulator):
         assert scene_lib is None, "Genesis does not support spawning objects in the scene"
         
         # Initialize the Genesis engine
-        gs.init(backend=gs.gpu)
+        gs.init(backend=gs.cpu) if device.type == "cpu" else gs.init(backend=gs.gpu)
         self._create_sim(visualization_markers)
 
     def _create_sim(self, visualization_markers: Dict) -> None:
@@ -138,8 +138,8 @@ class GenesisSimulator(Simulator):
                 dof_limits_upper.extend(joint.dofs_limit[:, 1])
 
         self._genesis_dof_indices = torch.tensor(self._genesis_dof_indices, device=self.device)
-        self._dof_limits_lower_sim = torch.tensor(dof_limits_lower, device=self.device)
-        self._dof_limits_upper_sim = torch.tensor(dof_limits_upper, device=self.device)
+        self._dof_limits_lower_sim = torch.tensor(dof_limits_lower, device=self.device, dtype=gs.tc_float)
+        self._dof_limits_upper_sim = torch.tensor(dof_limits_upper, device=self.device, dtype=gs.tc_float)
         
         self._scene.build(n_envs=self.num_envs)
         

--- a/protomotions/train_agent.py
+++ b/protomotions/train_agent.py
@@ -5,6 +5,7 @@ os.environ["WANDB_SILENT"] = "true"
 os.environ["WANDB_DISABLE_CODE"] = "true"
 
 import sys
+import platform
 from pathlib import Path
 import logging
 import hydra
@@ -43,6 +44,10 @@ log = logging.getLogger(__name__)
 
 @hydra.main(config_path="config", config_name="base")
 def main(config: OmegaConf):
+    if platform.system() == "Darwin":
+        log.info("Found OSX device")
+        config.fabric.accelerator = "mps"
+        config.fabric.strategy = "auto"
     # resolve=False is important otherwise overrides
     # at inference time won't work properly
     # also, I believe this must be done before instantiation

--- a/protomotions/utils/running_mean_std.py
+++ b/protomotions/utils/running_mean_std.py
@@ -21,10 +21,10 @@ class RunningMeanStd(nn.Module):
         super().__init__()
         self.epsilon = epsilon
         self.register_buffer(
-            "mean", torch.zeros(shape, dtype=torch.float64, device=device)
+            "mean", torch.zeros(shape, dtype=torch.float, device=device)
         )
         self.register_buffer(
-            "var", torch.ones(shape, dtype=torch.float64, device=device)
+            "var", torch.ones(shape, dtype=torch.float, device=device)
         )
         # self.count = epsilon
         self.register_buffer("count", torch.ones((), dtype=torch.long, device=device))

--- a/requirements_genesis.txt
+++ b/requirements_genesis.txt
@@ -16,7 +16,7 @@ matplotlib
 easydict
 wandb>=0.19.8
 tensorboardX
-sentry-sdk==1.9.10
+sentry-sdk>=1.9.10
 hydra-core==1.3.2
 PyOpenGL>=3.1.4
 # pydantic==1.10.9


### PR DESCRIPTION
Genesis simulator in ProtoMotions now runs on macOS.
The following changes were made:
-  Some operations were changed from float64 to float32 since MPS currently does not support float64.
-  Rendering-related code was modified to support macOS.

Note:
When running on MPS devices, Torch JIT can cause errors.
To avoid this, please run the script with JIT disabled:
`PYTORCH_JIT=0 python3 protomotions/train_agent.py ~`