### PR TITLE
fix(data): add PYTHONPATH to subprocess calls in conversion scripts

### DIFF
--- a/data/scripts/convert_amass_to_motionlib.py
+++ b/data/scripts/convert_amass_to_motionlib.py
@@ -32,6 +32,7 @@ This will create:
 """
 
 import argparse
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -157,7 +158,9 @@ Examples:
         convert_cmd.extend(["--motion-config", str(config)])
 
     print(f"Running: {' '.join(convert_cmd)}")
-    result = subprocess.run(convert_cmd, cwd=project_root)
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(project_root) + os.pathsep + env.get("PYTHONPATH", "")
+    result = subprocess.run(convert_cmd, cwd=project_root, env=env)
 
     if result.returncode != 0:
         print(f"Error: AMASS conversion failed with return code {result.returncode}")
@@ -207,7 +210,7 @@ Examples:
         ]
 
         print(f"Running: {' '.join(package_cmd)}")
-        result = subprocess.run(package_cmd, cwd=project_root)
+        result = subprocess.run(package_cmd, cwd=project_root, env=env)
 
         # Clean up temp file
         temp_yaml.unlink()

--- a/data/scripts/convert_phuma_to_motionlib.py
+++ b/data/scripts/convert_phuma_to_motionlib.py
@@ -35,6 +35,7 @@ This will create:
 """
 
 import argparse
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -152,7 +153,9 @@ def main():
         convert_cmd.append("--force-remake")
 
     print(f"Running: {' '.join(convert_cmd)}")
-    result = subprocess.run(convert_cmd, cwd=project_root)
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(project_root) + os.pathsep + env.get("PYTHONPATH", "")
+    result = subprocess.run(convert_cmd, cwd=project_root, env=env)
 
     if result.returncode != 0:
         print(f"Error: PHUMA conversion failed with return code {result.returncode}")
@@ -202,7 +205,7 @@ def main():
         ]
 
         print(f"Running: {' '.join(package_cmd)}")
-        result = subprocess.run(package_cmd, cwd=project_root)
+        result = subprocess.run(package_cmd, cwd=project_root, env=env)
 
         # Clean up temp file
         temp_yaml.unlink()


### PR DESCRIPTION
## Summary
- Fix `ModuleNotFoundError: No module named 'data.smpl'` in conversion scripts
- Both `convert_amass_to_motionlib.py` and `convert_phuma_to_motionlib.py` call subprocess with `cwd=project_root` but didn't set `PYTHONPATH`
- Child processes now inherit PYTHONPATH with project root prepended

## Test plan
- [x] Run `python data/scripts/convert_amass_to_motionlib.py` with AMASS data
- [x] Run `python data/scripts/convert_phuma_to_motionlib.py` with PHUMA data