### PR TITLE
fix: Connect SceneLib humanoid_motion_id to MotionManager

### DIFF
--- a/protomotions/envs/base_env/env.py
+++ b/protomotions/envs/base_env/env.py
@@ -1243,17 +1243,24 @@ class BaseEnv:
     # Motion and Visualization Helpers
     ###############################################################
     def create_motion_manager(self):
-        """Instantiate motion manager from configuration.
-
-        Creates the motion manager for sampling and tracking reference motions.
-        """
+        """Instantiate motion manager from configuration."""
         MotionManagerClass = get_class(self.config.motion_manager._target_)
+
+        fixed_motion_ids = None
+        if self.scene_lib.num_scenes() > 0:
+            humanoid_motion_ids = self.scene_lib.get_humanoid_motion_ids()
+            if humanoid_motion_ids is not None:
+                fixed_motion_ids = torch.tensor(
+                    humanoid_motion_ids, dtype=torch.long, device=self.device
+                )
+
         self.motion_manager = MotionManagerClass(
             config=self.config.motion_manager,
             num_envs=self.num_envs,
             env_dt=self.dt,
             device=self.device,
             motion_lib=self.motion_lib,
+            fixed_motion_ids_per_env=fixed_motion_ids,
         )
 
     def create_visualization_markers(self, headless: bool):

--- a/protomotions/envs/motion_manager/mimic_motion_manager.py
+++ b/protomotions/envs/motion_manager/mimic_motion_manager.py
@@ -17,16 +17,14 @@ from protomotions.envs.motion_manager.config import MimicMotionManagerConfig
 from protomotions.envs.motion_manager.motion_manager import MotionManager
 from protomotions.components.motion_lib import MotionLib
 import torch
-from typing import Optional, Tuple
-import numpy as np
+from typing import Optional
 
 
 class MimicMotionManager(MotionManager):
-    """Motion manager specialized for mimic environments with fixed motion support.
+    """Motion manager specialized for mimic environments.
 
     Extends the base MotionManager to handle mimic-specific motion sampling,
-    including support for fixed motion assignments per environment and
-    conditional resampling on reset.
+    including time progression and conditional resampling on reset.
     """
 
     config: MimicMotionManagerConfig
@@ -50,67 +48,7 @@ class MimicMotionManager(MotionManager):
             motion_lib (MotionLib): Motion library containing reference motions
             fixed_motion_ids_per_env (Optional[torch.Tensor], optional): If provided, specifies fixed motion IDs to use for each environment. Defaults to None.
         """
-        super().__init__(config, num_envs, env_dt, device, motion_lib)
-
-        self._fixed_motion_ids_per_env = fixed_motion_ids_per_env
-        self._env_has_fixed_motion = torch.zeros(
-            num_envs, device=device, dtype=torch.bool
-        )
-        if fixed_motion_ids_per_env is not None:
-            assert fixed_motion_ids_per_env.shape == (
-                num_envs,
-            ), "fixed_motion_ids_per_env must be of shape (num_envs,)"
-            self._env_has_fixed_motion = fixed_motion_ids_per_env != -1
-
-    def get_unique_fixed_motions(self) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Get unique fixed motion IDs and the first environment index for each, using NumPy.
-
-        Returns:
-            Tuple containing:
-                - Tensor of unique motion IDs (excluding -1 which indicates no fixed motion)
-                - Tensor of first environment indices for each unique motion ID
-        """
-        empty_result = (
-            torch.tensor([], device=self.device, dtype=torch.long),
-            torch.tensor([], device=self.device, dtype=torch.long),
-        )
-
-        if self._fixed_motion_ids_per_env is None:
-            return empty_result
-
-        # Mask for valid motion IDs (not -1)
-        valid_mask_torch = self._fixed_motion_ids_per_env != -1
-
-        if not valid_mask_torch.any():
-            return empty_result
-
-        # Convert to NumPy to use NumPy's unique function
-        fixed_motion_ids_np = self._fixed_motion_ids_per_env.cpu().numpy()
-        valid_mask_np = valid_mask_torch.cpu().numpy()
-
-        # Get the valid motion IDs in NumPy
-        valid_motion_ids_np = fixed_motion_ids_np[valid_mask_np]
-
-        # Get the original environment indices corresponding to valid motions (keep as Torch tensor)
-        all_env_indices_np = np.arange(len(self._fixed_motion_ids_per_env))
-        valid_env_indices_np = all_env_indices_np[valid_mask_np]
-
-        # Find unique motion IDs and the indices of their first occurrence within the *valid* NumPy array
-        unique_motion_ids_np, first_indices_in_valid_np = np.unique(
-            valid_motion_ids_np, return_index=True
-        )
-
-        # Get the corresponding environment indices using the first occurrence indices (NumPy indices -> Torch tensor)
-        first_env_indices_np = valid_env_indices_np[first_indices_in_valid_np]
-
-        first_env_indices_torch = torch.from_numpy(first_env_indices_np).to(
-            device=self.device, dtype=torch.long
-        )
-        unique_motion_ids_torch = torch.from_numpy(unique_motion_ids_np).to(
-            device=self.device, dtype=torch.long
-        )
-
-        return unique_motion_ids_torch, first_env_indices_torch
+        super().__init__(config, num_envs, env_dt, device, motion_lib, fixed_motion_ids_per_env)
 
     def get_done_tracks(self, env_ids: Optional[torch.Tensor] = None) -> torch.Tensor:
         """Check which motion tracks have reached their end time.
@@ -140,15 +78,14 @@ class MimicMotionManager(MotionManager):
     ):
         """Sample new motions for environments.
 
-        This overrides the base class to:
-        1. Handle mimic-specific resample_on_reset logic
-        2. Respect fixed motion IDs assigned to environments
+        Extends base class to handle mimic-specific resample_on_reset logic:
+        only resample motions that have finished playing.
 
         Args:
             env_ids (Tensor): Indices of the environments to reset.
             new_motion_ids (Tensor, optional):
                 Force new motion IDs for the reset environments.
-                If provided, this overrides the fixed motion IDs.
+                If provided, this overrides fixed motion IDs.
         """
         # Mimic-specific: Only resample motions that have finished if resample_on_reset is False
         reset_env_ids = env_ids
@@ -160,12 +97,5 @@ class MimicMotionManager(MotionManager):
         if len(reset_env_ids) == 0:
             return
 
-        # Handle fixed motion IDs for scene-based environments
-        if new_motion_ids is None and self._env_has_fixed_motion is not None:
-            # Check if any of the reset envs have fixed motions
-            if any(self._env_has_fixed_motion[reset_env_ids]):
-                # Use fixed motion IDs for those environments
-                new_motion_ids = self._fixed_motion_ids_per_env[reset_env_ids]
-
-        # Call parent sample_motions with the filtered env_ids
+        # Call parent sample_motions (handles fixed motion IDs)
         super().sample_motions(reset_env_ids, new_motion_ids)


### PR DESCRIPTION
Previously, Scene.humanoid_motion_id was defined but get_humanoid_motion_ids() was never called, leaving scene-motion correspondence disconnected.

Changes:
- Move fixed_motion_ids_per_env logic from MimicMotionManager to base MotionManager
- Connect SceneLib.get_humanoid_motion_ids() to MotionManager in BaseEnv.create_motion_manager()
- When scenes define humanoid_motion_id, environments now correctly use their assigned motion instead of random sampling

This enables workflows like vaulting where each scene has a specific reference motion that must be used for that environment.