### PR TITLE
Added support for specifying color to primitive scene objects

### DIFF
--- a/protomotions/components/scene_lib.py
+++ b/protomotions/components/scene_lib.py
@@ -70,7 +70,8 @@ class ObjectOptions:
     angular_damping: float = None
     linear_damping: float = None
     max_angular_velocity: float = None
-    texture_path: str = None  # Path to texture file
+    texture_path: str = None
+    color: Tuple = None
 
     def to_dict(self) -> Dict:
         """Convert options to a dictionary, excluding None values.

--- a/protomotions/simulator/isaaclab/simulator.py
+++ b/protomotions/simulator/isaaclab/simulator.py
@@ -240,7 +240,7 @@ class IsaacLabSimulator(Simulator):
                     spawn_cfg = sim_utils.CuboidCfg(
                         size=(obj.width, obj.depth, obj.height),
                         visual_material=sim_utils.PreviewSurfaceCfg(
-                            diffuse_color=(0.8, 0.3, 0.3), metallic=0.2
+                            diffuse_color=obj.options.color or (0.8, 0.3, 0.3), metallic=0.2
                         ),
                         rigid_props=rigid_props,
                         mass_props=sim_utils.MassPropertiesCfg(mass=-1, density=100),
@@ -250,7 +250,7 @@ class IsaacLabSimulator(Simulator):
                     spawn_cfg = sim_utils.SphereCfg(
                         radius=obj.radius,
                         visual_material=sim_utils.PreviewSurfaceCfg(
-                            diffuse_color=(0.3, 0.3, 0.8), metallic=0.2
+                            diffuse_color=obj.options.color or (0.3, 0.3, 0.8), metallic=0.2
                         ),
                         rigid_props=rigid_props,
                         mass_props=sim_utils.MassPropertiesCfg(
@@ -263,7 +263,7 @@ class IsaacLabSimulator(Simulator):
                         radius=obj.radius,
                         height=obj.height,
                         visual_material=sim_utils.PreviewSurfaceCfg(
-                            diffuse_color=(0.3, 0.8, 0.3), metallic=0.2
+                            diffuse_color=obj.options.color or (0.3, 0.8, 0.3), metallic=0.2
                         ),
                         rigid_props=rigid_props,
                         mass_props=sim_utils.MassPropertiesCfg(


### PR DESCRIPTION
Closes https://github.com/NVlabs/ProtoMotions/issues/200  

Validated that I was able to add two `BoxSceneObject` with different colors.    
The following image is an egocentric view from the G1 when loading the scene.  

<img width="1143" height="858" alt="image" src="https://github.com/user-attachments/assets/1e65ec08-ef90-4410-88e7-4f8a10030d17" />
