### PR TITLE
Fix incorrect MuJoCo gt_error during evaluation caused by root XY reset

### DIFF
--- a/protomotions/simulator/mujoco/config.py
+++ b/protomotions/simulator/mujoco/config.py
@@ -43,6 +43,13 @@ class MujocoSimulatorConfig(SimulatorConfig):
     _target_: str = "protomotions.simulator.mujoco.simulator.MujocoSimulator"
     sim: MujocoSimParams = field(default_factory=MujocoSimParams)
     w_last: bool = False  # MuJoCo uses wxyz quaternions
+    force_root_xy_to_origin_on_reset: bool = field(
+        default=True,
+        metadata={
+            "help": "If True, clamp root XY to the world origin on reset for single-env viewing. "
+                    "Disable this when you need metrics to stay aligned with respawned reference motions."
+        },
+    )
     use_implicit_pd: bool = field(
         default=True,
         metadata={

--- a/protomotions/simulator/mujoco/simulator.py
+++ b/protomotions/simulator/mujoco/simulator.py
@@ -681,9 +681,10 @@ class MujocoSimulator(Simulator):
         dof_pos = new_states.dof_pos[0].cpu().numpy()
         dof_vel = new_states.dof_vel[0].cpu().numpy()
 
-        # Force XY to origin for single env (keep Z height from motion)
-        root_pos[0] = 0.0
-        root_pos[1] = 0.0
+        # Optional viewer convenience: keep the robot near the world origin.
+        if getattr(self.config, "force_root_xy_to_origin_on_reset", True):
+            root_pos[0] = 0.0
+            root_pos[1] = 0.0
 
         if self._has_free_joint:
             self.data.qpos[0:3] = root_pos


### PR DESCRIPTION

---

## Summary

Fixes a MuJoCo-specific issue where global tracking metrics (e.g. `eval/gt_error/mean`) become unrealistically large despite visually correct motion.

---

## Problem

When using `--simulator mujoco`:

* `eval/gt_error/mean` can be extremely large
* Motion looks visually reasonable
* Relative metrics remain normal

This indicates a global position misalignment rather than policy failure.

---

## Root Cause

MuJoCo reset logic forced the root XY position to `(0, 0)`, while reference motions retained respawn/world offsets.

👉 This introduced a constant world-space translation offset, inflating global metrics.

---

## Fix

Add a configurable flag:

```
simulator.force_root_xy_to_origin_on_reset
```

* Default: `True` (viewer-friendly behavior)
* For evaluation:

```bash
--overrides "simulator.force_root_xy_to_origin_on_reset=False"
```

This preserves the respawned root position and aligns robot and reference in world space.

---

## Changes

* Add config flag in `simulator/mujoco/config.py`
* Update reset logic in `simulator/mujoco/simulator.py`

---

## Validation

Before:

* `eval/gt_error/mean ≈ 196`

After:

* `eval/gt_error/mean ≈ 0.237`
* `eval/max_joint_error/mean ≈ 0.383`

---

## Usage

```bash
python protomotions/inference_agent.py \
  --checkpoint xxx/last.ckpt \
  --simulator mujoco \
  --num-envs 1 \
  --motion-file xxx/data.pt \
  --full-eval \
  --headless \
  --overrides "simulator.force_root_xy_to_origin_on_reset=False"
```

---

## Notes

* No changes to metric definitions or units
* Fix is MuJoCo-specific
* Prevents misleading global metrics during evaluation

---

