### PR TITLE
Add color support for scene objects across simulators

### DIFF
--- a/protomotions/components/scene_lib.py
+++ b/protomotions/components/scene_lib.py
@@ -71,6 +71,7 @@ class ObjectOptions:
     linear_damping: float = None
     max_angular_velocity: float = None
     texture_path: str = None  # Path to texture file
+    color: Optional[Tuple[float, float, float]] = None  # RGB color (0-1)
 
     def to_dict(self) -> Dict:
         """Convert options to a dictionary, excluding None values.

--- a/protomotions/simulator/isaacgym/simulator.py
+++ b/protomotions/simulator/isaacgym/simulator.py
@@ -840,8 +840,21 @@ class IsaacGymSimulator(Simulator):
             )
             self._object_indices.append(object_idx)
 
-            # Apply texture if specified in object options
+            # Apply visual properties from object options
             if hasattr(obj, "options") and obj.options is not None:
+                if obj.options.color is not None:
+                    r, g, b = obj.options.color
+                    num_bodies = self._gym.get_actor_rigid_body_count(
+                        env_ptr, object_handle
+                    )
+                    for body_idx in range(num_bodies):
+                        self._gym.set_rigid_body_color(
+                            env_ptr,
+                            object_handle,
+                            body_idx,
+                            gymapi.MESH_VISUAL,
+                            gymapi.Vec3(r, g, b),
+                        )
                 texture_path = obj.options.to_dict().get("texture_path")
                 if texture_path and not self.headless:
                     self._apply_texture_to_object(env_ptr, object_handle, texture_path)

--- a/protomotions/simulator/isaaclab/simulator.py
+++ b/protomotions/simulator/isaaclab/simulator.py
@@ -219,6 +219,9 @@ class IsaacLabSimulator(Simulator):
                     rest_offset=0.0,
                 )
 
+                # Resolve color: use object option if set, else per-type default
+                obj_color = obj.options.color if obj.options.color is not None else None
+
                 # Handle different object types
                 if isinstance(obj, MeshSceneObject):
                     main_dir_path = (
@@ -233,14 +236,16 @@ class IsaacLabSimulator(Simulator):
                         rigid_props=rigid_props,
                         collision_props=collision_props,
                         visual_material=sim_utils.PreviewSurfaceCfg(
-                            diffuse_color=(0.2, 0.7, 0.3), metallic=0.2
+                            diffuse_color=obj_color or (0.2, 0.7, 0.3),
+                            metallic=0.2,
                         ),
                     )
                 elif isinstance(obj, BoxSceneObject):
                     spawn_cfg = sim_utils.CuboidCfg(
                         size=(obj.width, obj.depth, obj.height),
                         visual_material=sim_utils.PreviewSurfaceCfg(
-                            diffuse_color=(0.8, 0.3, 0.3), metallic=0.2
+                            diffuse_color=obj_color or (0.8, 0.3, 0.3),
+                            metallic=0.2,
                         ),
                         rigid_props=rigid_props,
                         mass_props=sim_utils.MassPropertiesCfg(mass=-1, density=100),
@@ -250,7 +255,8 @@ class IsaacLabSimulator(Simulator):
                     spawn_cfg = sim_utils.SphereCfg(
                         radius=obj.radius,
                         visual_material=sim_utils.PreviewSurfaceCfg(
-                            diffuse_color=(0.3, 0.3, 0.8), metallic=0.2
+                            diffuse_color=obj_color or (0.3, 0.3, 0.8),
+                            metallic=0.2,
                         ),
                         rigid_props=rigid_props,
                         mass_props=sim_utils.MassPropertiesCfg(
@@ -263,7 +269,8 @@ class IsaacLabSimulator(Simulator):
                         radius=obj.radius,
                         height=obj.height,
                         visual_material=sim_utils.PreviewSurfaceCfg(
-                            diffuse_color=(0.3, 0.8, 0.3), metallic=0.2
+                            diffuse_color=obj_color or (0.3, 0.8, 0.3),
+                            metallic=0.2,
                         ),
                         rigid_props=rigid_props,
                         mass_props=sim_utils.MassPropertiesCfg(


### PR DESCRIPTION
## Summary

Supersedes [#201](https://github.com/NVlabs/ProtoMotions/pull/201) with a more comprehensive solution — adds color support to all simulators that implement scene objects (IsaacGym and IsaacLab), not just IsaacLab.

- Add `ObjectOptions.color` field (`Optional[Tuple[float, float, float]]`) for RGB color specification
- **IsaacGym**: Apply color via `set_rigid_body_color()` after object creation (texture still takes priority if both set)
- **IsaacLab**: Use color as `diffuse_color` in `PreviewSurfaceCfg`
- All simulators fall back to existing per-type defaults when color is unset

### Usage

```python
BoxSceneObject(
    width=1.0, depth=1.0, height=1.0,
    options=ObjectOptions(color=(0.2, 0.4, 0.8)),
)
```

### Not in scope
- Newton/Genesis/MuJoCo: no scene object playground implementation yet
- IsaacLab file-based textures: `PreviewSurfaceCfg` doesn't support them (would need `MdlFileCfg`)