### PR TITLE
fix: use ObjectOptions mass/density for all primitive scene objects

### DIFF
--- a/protomotions/components/scene_lib.py
+++ b/protomotions/components/scene_lib.py
@@ -51,10 +51,17 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+DEFAULT_PRIMITIVE_DENSITY: float = 1000.0  # kg/m³, typical physics sim default
+
+
 @dataclass
 class ObjectOptions:
     """
     Contains options for configuring object properties in the simulator.
+
+    Mass properties can be specified as either ``density`` (kg/m³) or
+    ``mass`` (kg), but not both.  When neither is set, density defaults
+    to :data:`DEFAULT_PRIMITIVE_DENSITY`.
     """
 
     fix_base_link: bool = field(default=None)
@@ -67,10 +74,19 @@ class ObjectOptions:
         }
     )
     density: float = None
+    mass: float = None
     angular_damping: float = None
     linear_damping: float = None
     max_angular_velocity: float = None
     texture_path: str = None  # Path to texture file
+
+    def __post_init__(self):
+        if self.density is not None and self.mass is not None:
+            raise ValueError(
+                "ObjectOptions: specify either 'density' or 'mass', not both."
+            )
+        if self.density is None and self.mass is None:
+            self.density = DEFAULT_PRIMITIVE_DENSITY
 
     def to_dict(self) -> Dict:
         """Convert options to a dictionary, excluding None values.
@@ -939,23 +955,31 @@ class SceneLibConfig:
     _target_: str = "protomotions.components.scene_lib.SceneLib"
     scene_file: str = field(
         default=None,
-        metadata={"help": "Path to scene file (.pt) to load. None for programmatic scenes."}
+        metadata={
+            "help": "Path to scene file (.pt) to load. None for programmatic scenes."
+        },
     )
     subset_method: Union[SubsetMethod, List[int]] = field(
         default=SubsetMethod.FIRST,
-        metadata={"help": "Method for subsetting scenes: 'first', 'random', 'sequential', or list of indices."}
+        metadata={
+            "help": "Method for subsetting scenes: 'first', 'random', 'sequential', or list of indices."
+        },
     )
     replicate_method: ReplicationMethod = field(
         default=ReplicationMethod.WEIGHTED,
-        metadata={"help": "Method for replicating scenes: 'first', 'weighted', 'random', 'sequential'."}
+        metadata={
+            "help": "Method for replicating scenes: 'first', 'weighted', 'random', 'sequential'."
+        },
     )
     pointcloud_samples_per_object: Optional[int] = field(
         default=None,
-        metadata={"help": "Number of pointcloud samples per object for observations. None to disable."}
+        metadata={
+            "help": "Number of pointcloud samples per object for observations. None to disable."
+        },
     )
     num_objects_per_env: int = field(
         default=None,
-        metadata={"help": "Number of objects per environment. Must match scene data."}
+        metadata={"help": "Number of objects per environment. Must match scene data."},
     )
 
 

--- a/protomotions/simulator/isaacgym/simulator.py
+++ b/protomotions/simulator/isaacgym/simulator.py
@@ -615,6 +615,13 @@ class IsaacGymSimulator(Simulator):
         object_asset_options.default_dof_drive_mode = gymapi.DOF_MODE_NONE
         object_options_dict = obj.options.to_dict()
 
+        # Without override_inertia the URDF's placeholder <inertial>
+        # block takes precedence over AssetOptions.density.
+        if isinstance(obj, PrimitiveSceneObject) and obj.options.mass is None:
+            object_asset_options.override_inertia = True
+
+        object_options_dict.pop("mass", None)
+
         if object_options_dict.get("vhacd_enabled", False):
             object_asset_options.vhacd_params = gymapi.VhacdParams()
         for key, value in object_options_dict.items():
@@ -672,6 +679,8 @@ class IsaacGymSimulator(Simulator):
         else:
             raise ValueError(f"Unsupported primitive shape: {obj.object_identifier}")
 
+        mass_value = obj.options.mass if obj.options.mass is not None else 1.0
+
         # Create the URDF XML content
         urdf_content = f"""<?xml version="1.0"?>
 <robot name="{obj.object_identifier}">
@@ -687,7 +696,7 @@ class IsaacGymSimulator(Simulator):
       </geometry>
     </collision>
     <inertial>
-      <mass value="1.0"/>
+      <mass value="{mass_value}"/>
       <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
     </inertial>
   </link>

--- a/protomotions/simulator/isaaclab/simulator.py
+++ b/protomotions/simulator/isaaclab/simulator.py
@@ -237,28 +237,29 @@ class IsaacLabSimulator(Simulator):
                         ),
                     )
                 elif isinstance(obj, BoxSceneObject):
+                    mass_props = self._mass_props_from_options(obj.options)
                     spawn_cfg = sim_utils.CuboidCfg(
                         size=(obj.width, obj.depth, obj.height),
                         visual_material=sim_utils.PreviewSurfaceCfg(
                             diffuse_color=(0.8, 0.3, 0.3), metallic=0.2
                         ),
                         rigid_props=rigid_props,
-                        mass_props=sim_utils.MassPropertiesCfg(mass=-1, density=100),
+                        mass_props=mass_props,
                         collision_props=collision_props,
                     )
                 elif isinstance(obj, SphereSceneObject):
+                    mass_props = self._mass_props_from_options(obj.options)
                     spawn_cfg = sim_utils.SphereCfg(
                         radius=obj.radius,
                         visual_material=sim_utils.PreviewSurfaceCfg(
                             diffuse_color=(0.3, 0.3, 0.8), metallic=0.2
                         ),
                         rigid_props=rigid_props,
-                        mass_props=sim_utils.MassPropertiesCfg(
-                            mass=-1, density=obj.options.density
-                        ),
+                        mass_props=mass_props,
                         collision_props=collision_props,
                     )
                 elif isinstance(obj, CylinderSceneObject):
+                    mass_props = self._mass_props_from_options(obj.options)
                     spawn_cfg = sim_utils.CylinderCfg(
                         radius=obj.radius,
                         height=obj.height,
@@ -266,9 +267,7 @@ class IsaacLabSimulator(Simulator):
                             diffuse_color=(0.3, 0.8, 0.3), metallic=0.2
                         ),
                         rigid_props=rigid_props,
-                        mass_props=sim_utils.MassPropertiesCfg(
-                            mass=-1, density=obj.options.density
-                        ),
+                        mass_props=mass_props,
                         collision_props=collision_props,
                     )
                 else:
@@ -277,6 +276,17 @@ class IsaacLabSimulator(Simulator):
                 objects_cfgs[obj_idx].append(spawn_cfg)
 
         return objects_cfgs, initial_obj_pos
+
+    @staticmethod
+    def _mass_props_from_options(options):
+        """Build ``MassPropertiesCfg`` from :class:`ObjectOptions`.
+
+        If ``options.mass`` is set, use explicit mass (density disabled).
+        Otherwise use ``options.density`` (always set by ObjectOptions).
+        """
+        if options.mass is not None:
+            return sim_utils.MassPropertiesCfg(mass=options.mass, density=-1)
+        return sim_utils.MassPropertiesCfg(mass=-1, density=options.density)
 
     def _setup_keyboard(self) -> None:
         """


### PR DESCRIPTION
## Summary

- Add `mass` field to `ObjectOptions` (mutually exclusive with `density`, validated in `__post_init__`)
- Default to `1000 kg/m³` when neither mass nor density is specified
- Fix IsaacLab `BoxSceneObject` hardcoded `density=100` — all three primitives now use `_mass_props_from_options()`
- Fix IsaacGym all primitives hardcoded `mass=1.0` in URDF — now respects `ObjectOptions.mass` or `ObjectOptions.density`

Closes https://github.com/NVlabs/ProtoMotions/issues/206