### PR TITLE
fix: plumb ProjectileConfig through SimulatorConfig

### DIFF
--- a/protomotions/simulator/base_simulator/config.py
+++ b/protomotions/simulator/base_simulator/config.py
@@ -465,6 +465,15 @@ class SimulatorConfig:
             "help": "Domain randomization configuration for sim-to-real transfer."
         },
     )
+    projectile: ProjectileConfig = field(
+        default_factory=lambda: ProjectileConfig(),
+        metadata={
+            "help": (
+                "Projectile cube perturbation configuration (J-key throws). "
+                "Set num_projectiles=0 to disable projectiles."
+            )
+        },
+    )
     pd_target_max_accel: Optional[float] = field(
         default=None,
         metadata={

--- a/protomotions/simulator/base_simulator/simulator.py
+++ b/protomotions/simulator/base_simulator/simulator.py
@@ -408,9 +408,27 @@ class Simulator(RecordingMixin, ABC):
         """
         raise NotImplementedError
 
+    def _resolve_proj_config(self) -> "ProjectileConfig":
+        """Resolve and cache the active projectile config.
+
+        Reads ``self.config.projectile`` when present (fresh configs default
+        to a ``ProjectileConfig`` instance via ``SimulatorConfig``), falling
+        back to a default for legacy ``resolved_configs.pt`` pickles that
+        predate the field. Cached on ``self._proj_config`` so callers get
+        the same instance whether invoked from a backend ``__init__`` (which
+        needs the config before scene construction) or later from
+        ``_init_projectiles``. To disable projectiles, set
+        ``SimulatorConfig.projectile.num_projectiles = 0``.
+        """
+        if not hasattr(self, "_proj_config"):
+            self._proj_config = (
+                getattr(self.config, "projectile", None) or ProjectileConfig()
+            )
+        return self._proj_config
+
     def _init_projectiles(self) -> None:
         """Initialize projectile pool state and create physics bodies."""
-        self._proj_config = ProjectileConfig()
+        self._resolve_proj_config()
         N = self._proj_config.num_projectiles
 
         self._proj_next_idx = torch.zeros(

--- a/protomotions/simulator/isaacgym/simulator.py
+++ b/protomotions/simulator/isaacgym/simulator.py
@@ -116,8 +116,8 @@ class IsaacGymSimulator(Simulator):
         Called by base class _initialize_with_markers() after visualization markers
         are set. Creates simulation, viewer, and acquires tensors.
         """
-        # Pre-create projectile config (needed before _init_projectiles runs)
-        self._proj_config = ProjectileConfig()
+        # Scene construction below needs _proj_config before _init_projectiles runs
+        self._resolve_proj_config()
 
         # Update marker names ordering from visualization markers
         self._marker_names_ordering = (

--- a/protomotions/simulator/isaaclab/simulator.py
+++ b/protomotions/simulator/isaaclab/simulator.py
@@ -116,8 +116,8 @@ class IsaacLabSimulator(Simulator):
         self._sim = SimulationContext(sim_cfg)
         self._sim.set_camera_view([2.5, 0.0, 4.0], [0.0, 0.0, 2.0])
 
-        # Pre-create projectile config (needed before _init_projectiles runs)
-        self._proj_config = ProjectileConfig()
+        # Scene construction below needs _proj_config before _init_projectiles runs
+        self._resolve_proj_config()
 
         scene_cfg = self._get_scene_cfg()
 

--- a/protomotions/simulator/mujoco/simulator.py
+++ b/protomotions/simulator/mujoco/simulator.py
@@ -292,8 +292,8 @@ class MujocoSimulator(Simulator):
         asset_file = self.robot_config.asset.asset_file_name
         asset_path = os.path.join(asset_root, asset_file)
 
-        # Pre-create projectile config so we can inject bodies into MJCF
-        self._proj_config = ProjectileConfig()
+        # MJCF injection below needs _proj_config before _init_projectiles runs
+        self._resolve_proj_config()
 
         log.info("Loading MuJoCo model from: %s", asset_path)
         self.model = self._load_mjcf_stripped(asset_path, self._proj_config)

--- a/protomotions/simulator/newton/simulator.py
+++ b/protomotions/simulator/newton/simulator.py
@@ -213,7 +213,7 @@ class NewtonSimulator(Simulator):
         self.robot.approximate_meshes("convex_hull")
 
         # 5. Add projectile free bodies to the builder (before replicate)
-        self._proj_config = ProjectileConfig()
+        self._resolve_proj_config()
         proj_sizes = self._proj_config.get_sizes()
         shape_cfg = newton.ModelBuilder.ShapeConfig(
             density=self._proj_config.density,


### PR DESCRIPTION
## Summary

Issue [#210](https://github.com/NVlabs/ProtoMotions/issues/210) exposed a latent bug: `BaseSimulator._init_projectiles()` unconditionally did `self._proj_config = ProjectileConfig()`, wiping any value set earlier by a backend. IsaacLab/IsaacGym/MuJoCo/Newton pre-create `_proj_config` in their own `__init__` because scene construction needs it before base `_finalize_setup` runs (`isaaclab/simulator.py:120`, `isaacgym/simulator.py:120`, `mujoco/simulator.py:296`, `newton/simulator.py:216`). Genesis (`genesis/simulator.py:430`) relies on the base class to create it.

Today the overwrite replaces a default with an identical default, so the bug is strictly latent — but any backend-side customization gets silently reverted, which is exactly what issue #210's `num_projectiles=0` workaround hit.

## Change

Rather than just guarding the overwrite, plumb projectile config into the user-facing config system.

1. **Add `projectile: ProjectileConfig` field to `SimulatorConfig`** (`base_simulator/config.py`) with `default_factory` so fresh configs always carry a concrete object. Mirrors the existing `domain_randomization` field. CLI `--overrides` can now walk attributes like `simulator.projectile.num_projectiles=0`.
2. **Add `Simulator._resolve_proj_config()` helper** (`base_simulator/simulator.py`) that reads `self.config.projectile` with a `getattr` fallback to a default `ProjectileConfig()`. The fallback covers legacy `resolved_configs.pt` pickles that predate the field (training resume loads configs directly via `torch.load` with no migration hook). Cached on `self._proj_config`, so the helper is idempotent whether called from a backend `__init__` or later from `_init_projectiles`.
3. **Five duplicate `self._proj_config = ProjectileConfig()` sites collapse to one call** each to `self._resolve_proj_config()` — in the four pre-creating backends' `__init__` and in the base `_init_projectiles` (which closes the Genesis gap).

Behaviors:
- Fresh configs → `self.config.projectile` (the default factory instance) is used directly. Same instance identity at all read sites.
- Legacy pickles without the new field → `getattr(..., None)` returns None → fallback to `ProjectileConfig()`.
- Disabling projectiles → set `num_projectiles = 0`. The resolver won't fall back because a `ProjectileConfig` instance is always truthy (no `__bool__` override).

## Verification

Smoke-checked all three paths (fresh / legacy / disabled) in a standalone Python snippet before pushing — resolver returns the expected config in each case and preserves instance identity for the fresh path. Ruff formatter clean on modified lines; pre-existing `E402` import-order errors on `base_simulator/simulator.py` / `mujoco/simulator.py` are untouched.
