### PR TITLE
fix: restore scene object state in BaseEnv.save_state / restore_state

### DIFF
--- a/protomotions/envs/base_env/env.py
+++ b/protomotions/envs/base_env/env.py
@@ -1482,6 +1482,8 @@ class BaseEnv:
             snapshot["_current_noisy_obs"] = NoisyObservations(
                 **{f.name: getattr(noisy, f.name).clone() for f in dc_fields(noisy)}
             )
+        if self.scene_lib.num_objects_per_scene > 0:
+            snapshot["object_state"] = self.simulator.get_object_root_state()
         return snapshot
 
     def restore_state(self, snapshot: dict) -> None:
@@ -1494,7 +1496,9 @@ class BaseEnv:
             snapshot: Dictionary from save_state() containing state tensors
         """
         env_ids = torch.arange(self.num_envs, device=self.device)
-        self.simulator.reset_envs(snapshot["robot_state"], None, env_ids)
+        self.simulator.reset_envs(
+            snapshot["robot_state"], snapshot.get("object_state"), env_ids
+        )
 
         if "state_history" in snapshot and self.state_history is not None:
             self.state_history.load_state(snapshot["state_history"])


### PR DESCRIPTION
## Summary

Fixes [#209](https://github.com/NVlabs/ProtoMotions/issues/209).

`BaseEnv.save_state()` snapshotted robot state, markers, actions, and various buffers — but never called `simulator.get_object_root_state()`. `BaseEnv.restore_state()` then hardcoded `None` as the `new_object_states` argument to `simulator.reset_envs(...)`. After an evaluator run that moved scene objects (boxes, etc.), `restore_state()` would teleport the robot back to its saved pose while leaving scene objects in whatever pose eval had left them.

The standard `env.reset()` path at `protomotions/envs/base_env/env.py:1108` already passed both robot *and* object state through `simulator.reset_envs(new_states, new_object_states, env_ids)`, confirming the underlying API supported what save/restore omitted.

## Change

`protomotions/envs/base_env/env.py`:

- **`save_state()`** — snapshot `self.simulator.get_object_root_state()` when the scene library has objects.
- **`restore_state()`** — pass `snapshot.get("object_state")` (returns `None` when the key is absent, preserving current behavior for scene-less runs) through to `simulator.reset_envs`.

```python
# save_state:
if self.scene_lib.num_objects_per_scene > 0:
    snapshot["object_state"] = self.simulator.get_object_root_state()

# restore_state:
self.simulator.reset_envs(
    snapshot["robot_state"], snapshot.get("object_state"), env_ids
)
```

Guard is on `num_objects_per_scene > 0` rather than `num_scenes() > 0` because `SceneLib._assign_scene_offsets` (`protomotions/components/scene_lib.py:1458-1468`) only validates equal object counts across scenes, not positive counts — so a non-empty `SceneLib` with `num_objects_per_scene == 0` is legal today and would otherwise break the backend's `_get_simulator_object_root_state` (which `torch.stack`s per-object lists).

## Notes

- No explicit `.clone()` needed in `save_state`: scene-capable backends (IsaacLab at `simulator/isaaclab/simulator.py:774-779`, IsaacGym at `simulator/isaacgym/simulator.py:1150-1168`) clone the underlying `root_*_w` tensors before constructing the returned `ObjectState`.
- `reset_envs` at `protomotions/simulator/base_simulator/simulator.py:684-685` already converts a non-`None` `ObjectState` from COMMON → SIMULATOR via `convert_to_sim`, so passing the saved COMMON-form state is correct.
- Only caller of `BaseEnv.save_state()` / `restore_state()` is `protomotions/agents/evaluators/mimic_evaluator.py:87,272`; no other call sites need updating.

Credit to @jbae49 for the diagnosis and fix sketch.
