### PR TITLE
Fix #210: spread projectile hide poses to avoid PhysX collision/memory pressure

### DIFF
--- a/protomotions/simulator/base_simulator/simulator.py
+++ b/protomotions/simulator/base_simulator/simulator.py
@@ -517,7 +517,18 @@ class Simulator(RecordingMixin, ABC):
         self._hide_projectiles_for_envs(all_env_ids)
 
     def _hide_projectiles_for_envs(self, env_ids: torch.Tensor) -> None:
-        """Move all projectiles for given envs underground."""
+        """Move all projectiles for given envs underground.
+
+        Each (env, proj_idx) slot is given a unique hide position
+        ``(env_id * N + proj_idx, 0, hide_z)`` rather than the same world
+        ``(0, 0, hide_z)``. With many environments and multiple projectiles,
+        colocating every projectile rigid body at one world point causes a
+        broadphase / actor-aliasing pathology in PhysX (issue #210) where the
+        projectile's hide pose ends up stamped onto unrelated scene-object
+        bodies on a subsequent physics step. Spreading by 1m per slot keeps
+        each cube actor in a distinct world cell, breaking the aliasing while
+        leaving projectiles equally hidden from active gameplay.
+        """
         N = self._proj_config.num_projectiles
         num_e = len(env_ids)
 
@@ -526,6 +537,7 @@ class Simulator(RecordingMixin, ABC):
         proj_expanded = torch.arange(N, device=self.device).repeat(num_e)
 
         hide_pos = torch.zeros(len(env_expanded), 3, device=self.device)
+        hide_pos[:, 0] = env_expanded.float() * float(N) + proj_expanded.float()
         hide_pos[:, 2] = self._proj_config.hide_z
         zero_rot = torch.zeros(len(env_expanded), 4, device=self.device)
         zero_rot[:, 3] = 1.0


### PR DESCRIPTION
## Summary

Fixes [#210](https://github.com/NVlabs/ProtoMotions/issues/210). ``_hide_projectiles_for_envs`` previously reset every projectile rigid body to the same world point ``(0, 0, hide_z)``. With many envs and multiple cuboid projectiles, this batched-reset to a single colocated point appears to overwhelm something inside PhysX — most likely contact / broadphase pair tracking or related GPU memory state — and on a subsequent physics step the corrupted internal state surfaces as scene-object PhysX bodies inheriting the projectile's hide pose. The visible artifact in training is the scene-object box snapping to byte-exact ``(0, 0, hide_z)`` and tracking-error spikes; the underlying problem is a PhysX-level resource issue when we resolve thousands of cube actors at the same world cell every reset.

The fix gives each ``(env, proj_idx)`` slot a unique world XY ``(env_id * N + proj_idx, 0, hide_z)`` so the cube actors live in distinct cells. Hidden-from-gameplay semantics unchanged, no perf cost.

## How we got here

Eleven experiments narrowed the trigger to **all** of:
- **Cuboid** projectile primitive (sphere projectiles never reproduce).
- **At least 2 projectiles per env** (``num_projectiles=1`` never reproduces).
- **Sufficient envs** (4096 reproduces; 2048 doesn't within 21k steps).
- The ``_hide_projectiles_for_envs`` write itself (skipping it never reproduces).
- **Colocation** of every projectile rigid body at one world point on each reset.

The colocation requirement was the deciding test: spreading projectiles in world XY prevented the bug across a 50k-step Path B training run at 4096 envs with 5 cuboid projectiles (i.e. every other reproduction condition still satisfied). Zero ``[FDUMP]`` fires; max ``obj_pos_err`` stayed at 0.99m vs. the 1282m bug signature.

A separate diagnostic confirmed the value being stamped onto scene-object bodies is the projectile's ``default_root_pose``: overriding ``hide_z=-5`` shifts the snap symmetrically to ``(0, 0, -5)``. That is consistent with PhysX-level state from the colocated projectile reset leaking into adjacent actor slots — exactly what a broadphase / contact-buffer pressure issue would produce.