### PR TITLE
Fix MaskedMimic full eval config

### DIFF
--- a/data/pretrained_models/masked_mimic/smpl/experiment_config.py
+++ b/data/pretrained_models/masked_mimic/smpl/experiment_config.py
@@ -521,8 +521,6 @@ def apply_inference_overrides(
     )
     apply_inference_overrides_fn(robot_cfg, simulator_cfg, env_cfg, agent_cfg, terrain_cfg, motion_lib_cfg, scene_lib_cfg, args)
 
-    from protomotions.agents.evaluators.config import EvaluatorConfig
-
     if agent_cfg is not None and hasattr(agent_cfg, "expert_model_path"):
         expert_model_path = agent_cfg.expert_model_path
         
@@ -540,4 +538,3 @@ def apply_inference_overrides(
                         del env_cfg.observation_components[key]
         
         agent_cfg.expert_model_path = None
-        agent_cfg.evaluator = EvaluatorConfig()

--- a/data/pretrained_models/masked_mimic/smpl/resolved_configs_inference.pt
+++ b/data/pretrained_models/masked_mimic/smpl/resolved_configs_inference.pt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:289732196f450108c95e9fea96349cc2886cf794bab390445f8a705d780fbe51
-size 41893
+oid sha256:4e6d4df8dfd92757b1207277dfbc5fff9414005d4f55a5296f7ea74ac77ee036
+size 43173

--- a/data/pretrained_models/masked_mimic/smpl/resolved_configs_inference.yaml
+++ b/data/pretrained_models/masked_mimic/smpl/resolved_configs_inference.yaml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6cb69410607fefac75a160eebb2012f5772fd5ce30974ab9bf54b4d47697050d
-size 52878
+oid sha256:de6a6f5bd30aaf6438ff172125617e35a737fef73d7bb219753aad22aea2a95e
+size 53749

--- a/examples/experiments/masked_mimic/transformer.py
+++ b/examples/experiments/masked_mimic/transformer.py
@@ -521,8 +521,6 @@ def apply_inference_overrides(
     )
     apply_inference_overrides_fn(robot_cfg, simulator_cfg, env_cfg, agent_cfg, terrain_cfg, motion_lib_cfg, scene_lib_cfg, args)
 
-    from protomotions.agents.evaluators.config import EvaluatorConfig
-
     if agent_cfg is not None and hasattr(agent_cfg, "expert_model_path"):
         expert_model_path = agent_cfg.expert_model_path
         
@@ -540,4 +538,3 @@ def apply_inference_overrides(
                         del env_cfg.observation_components[key]
         
         agent_cfg.expert_model_path = None
-        agent_cfg.evaluator = EvaluatorConfig()


### PR DESCRIPTION
## Summary
- keep the MaskedMimic evaluator in inference overrides
- update the packaged MaskedMimic inference config artifacts

## Verification
- py_compile on touched experiment files
- loaded resolved_configs_inference.pt and confirmed MimicEvaluator with gt_error, gr_error, and max_joint_error
- git diff --check

Fixes #216