### PR TITLE
Add scene object asset randomization

### DIFF
--- a/docs/source/tutorials/code_tutorials.rst
+++ b/docs/source/tutorials/code_tutorials.rst
@@ -163,7 +163,7 @@ Learn to add objects and create scenes for robot interaction.
 **What you'll learn**:
 
 * Create ``MeshSceneObject`` and ``BoxSceneObject`` with physics properties
-* Configure object options (density, damping, VHACD collision)
+* Configure object options (mass/density, damping, material, VHACD collision)
 * Compose scenes with multiple objects
 * Access object state during simulation
 
@@ -179,7 +179,14 @@ Learn to add objects and create scenes for robot interaction.
 
    elephant = MeshSceneObject(
        object_path="examples/data/elephant.urdf",
-       options=ObjectOptions(fix_base_link=False, density=1000, vhacd_enabled=True),
+       options=ObjectOptions(
+           fix_base_link=False,
+           density=1000,  # Use mass=... instead for explicit kg.
+           static_friction=0.8,
+           dynamic_friction=0.6,
+           restitution=0.0,
+           vhacd_enabled=True,
+       ),
        translation=(0.0, 0.0, 1.5),
    )
    table = BoxSceneObject(width=1.0, depth=1.0, height=0.1, ...)

--- a/docs/source/tutorials/workflows/domain_randomization.rst
+++ b/docs/source/tutorials/workflows/domain_randomization.rst
@@ -76,6 +76,41 @@ adjust ranges to suit your robot and deployment conditions.
    values are not explicitly set.  This ensures consistent behavior across
    simulators.
 
+**Scene Object Asset Randomization:**
+
+Scene objects can define deterministic base properties through
+``ObjectOptions``.  Mesh and primitive objects can set either ``mass`` or
+``density`` (not both), plus ``static_friction``, ``dynamic_friction``, and
+``restitution`` in the scene library.  ``ObjectAssetDomainRandomizationConfig``
+samples absolute override values for those properties; the sampled values
+replace the scene-lib base values for the selected asset bucket.  They are not
+additive or multiplicative offsets.  The ranges are global for all scene object
+assets; per-asset range configuration is not currently supported.
+
+.. code-block:: python
+
+   DomainRandomizationConfig(
+       object_assets=ObjectAssetDomainRandomizationConfig(
+           num_buckets=32,
+           static_friction_range=(0.4, 1.4),
+           dynamic_friction_range=(0.3, 1.0),
+           restitution_range=(0.0, 0.2),
+           mass_range=(0.5, 3.0),
+           center_of_mass_range={
+               "x": (-0.05, 0.05),
+               "y": (-0.02, 0.02),
+               "z": (0.00, 0.10),
+           },
+       )
+   )
+
+``mass_range`` and ``density_range`` are mutually exclusive, matching
+``ObjectOptions``.  ``center_of_mass_range`` is only available through domain
+randomization; it is an absolute local center-of-mass value, and omitted axes
+default to ``0.0``.  IsaacLab and IsaacGym apply these scene object asset
+properties to both primitive and mesh objects.  Newton currently does not spawn
+scene-lib objects, so object asset randomization has no effect there.
+
 **Center of Mass Randomization:**
 
 .. code-block:: python

--- a/protomotions/components/scene_lib.py
+++ b/protomotions/components/scene_lib.py
@@ -51,7 +51,8 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_PRIMITIVE_DENSITY: float = 1000.0  # kg/m³, typical physics sim default
+DEFAULT_OBJECT_DENSITY: float = 1000.0  # kg/m³, typical physics sim default
+DEFAULT_PRIMITIVE_DENSITY: float = DEFAULT_OBJECT_DENSITY
 
 
 @dataclass
@@ -61,7 +62,7 @@ class ObjectOptions:
 
     Mass properties can be specified as either ``density`` (kg/m³) or
     ``mass`` (kg), but not both.  When neither is set, density defaults
-    to :data:`DEFAULT_PRIMITIVE_DENSITY`.
+    to :data:`DEFAULT_OBJECT_DENSITY`.
     """
 
     fix_base_link: bool = field(default=None)
@@ -78,6 +79,9 @@ class ObjectOptions:
     angular_damping: float = None
     linear_damping: float = None
     max_angular_velocity: float = None
+    static_friction: float = None
+    dynamic_friction: float = None
+    restitution: float = None
     texture_path: str = None  # Path to texture file
     color: Optional[Tuple[float, float, float]] = None  # RGB color (0-1)
 
@@ -87,7 +91,7 @@ class ObjectOptions:
                 "ObjectOptions: specify either 'density' or 'mass', not both."
             )
         if self.density is None and self.mass is None:
-            self.density = DEFAULT_PRIMITIVE_DENSITY
+            self.density = DEFAULT_OBJECT_DENSITY
 
     def to_dict(self) -> Dict:
         """Convert options to a dictionary, excluding None values.
@@ -108,6 +112,56 @@ class ObjectOptions:
             else:
                 options_dict[field_name] = field_value
         return options_dict
+
+    def physics_material_kwargs(self) -> Dict[str, float]:
+        """Return explicitly configured physics material properties."""
+        return {
+            field_name: getattr(self, field_name)
+            for field_name in ("static_friction", "dynamic_friction", "restitution")
+            if getattr(self, field_name) is not None
+        }
+
+    def single_friction(self) -> Optional[float]:
+        """Return one friction value for backends without static/dynamic split."""
+        if self.static_friction is not None:
+            return self.static_friction
+        return self.dynamic_friction
+
+    def single_friction_material_kwargs(
+        self, friction_key: str = "friction"
+    ) -> Dict[str, float]:
+        """Return material kwargs for backends with one friction coefficient."""
+        material_kwargs = {}
+        friction = self.single_friction()
+        if friction is not None:
+            material_kwargs[friction_key] = friction
+        if self.restitution is not None:
+            material_kwargs["restitution"] = self.restitution
+        return material_kwargs
+
+    def with_asset_property_overrides(self, overrides: Dict[str, float]):
+        """Return a copy with absolute object-asset DR overrides applied."""
+        allowed_fields = {
+            "mass",
+            "density",
+            "static_friction",
+            "dynamic_friction",
+            "restitution",
+        }
+        unknown_fields = set(overrides) - allowed_fields
+        if unknown_fields:
+            raise ValueError(f"Unknown object asset override fields: {unknown_fields}")
+        if "mass" in overrides and "density" in overrides:
+            raise ValueError("Object asset overrides cannot set both mass and density.")
+
+        options = copy.copy(self)
+        for field_name, value in overrides.items():
+            setattr(options, field_name, value)
+        if "mass" in overrides:
+            options.density = None
+        if "density" in overrides:
+            options.mass = None
+        return options
 
 
 @dataclass

--- a/protomotions/simulator/base_simulator/config.py
+++ b/protomotions/simulator/base_simulator/config.py
@@ -165,6 +165,132 @@ class FrictionDomainRandomizationConfig:
 
 
 @dataclass
+class ObjectAssetDomainRandomizationConfig:
+    """Configuration for scene object asset domain randomization.
+
+    Ranges are absolute sampled values. When a range is set, it overrides the
+    matching base value from each scene object's ObjectOptions.
+    """
+
+    num_buckets: int = field(
+        default=10,
+        metadata={"help": "Number of object asset property buckets.", "min": 1},
+    )
+    static_friction_range: Optional[Tuple[float, float]] = field(
+        default=None,
+        metadata={"help": "Absolute range (min, max) for object static friction."},
+    )
+    dynamic_friction_range: Optional[Tuple[float, float]] = field(
+        default=None,
+        metadata={"help": "Absolute range (min, max) for object dynamic friction."},
+    )
+    restitution_range: Optional[Tuple[float, float]] = field(
+        default=None,
+        metadata={"help": "Absolute range (min, max) for object restitution."},
+    )
+    mass_range: Optional[Tuple[float, float]] = field(
+        default=None, metadata={"help": "Absolute range (min, max) for object mass."}
+    )
+    density_range: Optional[Tuple[float, float]] = field(
+        default=None,
+        metadata={"help": "Absolute range (min, max) for object density."},
+    )
+    center_of_mass_range: Optional[Dict[str, Tuple[float, float]]] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Absolute local center-of-mass range per axis, e.g. "
+                "{'x': (-0.05, 0.05), 'y': (0.0, 0.0), 'z': (0.0, 0.1)}."
+            )
+        },
+    )
+
+    def __post_init__(self):
+        if self.num_buckets < 1:
+            raise ValueError("num_buckets must be at least 1.")
+        if self.mass_range is not None and self.density_range is not None:
+            raise ValueError("Only one of mass_range or density_range may be set.")
+
+        range_fields = (
+            "static_friction_range",
+            "dynamic_friction_range",
+            "restitution_range",
+            "mass_range",
+            "density_range",
+            "center_of_mass_range",
+        )
+        if all(getattr(self, field_name) is None for field_name in range_fields):
+            raise ValueError(
+                "At least one object asset randomization range is required."
+            )
+        for field_name in range_fields:
+            value_range = getattr(self, field_name)
+            if value_range is None:
+                continue
+            if field_name == "center_of_mass_range":
+                self._validate_center_of_mass_range(value_range)
+                continue
+            if len(value_range) != 2 or value_range[0] >= value_range[1]:
+                raise ValueError(
+                    f"{field_name} must be a tuple of two values where min < max."
+                )
+
+    @staticmethod
+    def _validate_center_of_mass_range(
+        center_of_mass_range: Dict[str, Tuple[float, float]],
+    ) -> None:
+        if not center_of_mass_range:
+            raise ValueError("center_of_mass_range must define at least one axis.")
+        invalid_axes = set(center_of_mass_range) - {"x", "y", "z"}
+        if invalid_axes:
+            raise ValueError(
+                f"center_of_mass_range contains invalid axes: {invalid_axes}"
+            )
+        for axis, value_range in center_of_mass_range.items():
+            # Equal bounds let configs pin an axis while randomizing others.
+            if len(value_range) != 2 or value_range[0] > value_range[1]:
+                raise ValueError(
+                    f"center_of_mass_range['{axis}'] must be a tuple of two values where min <= max."
+                )
+
+    def sample(self, num_samples: int, num_assets: int, device=None) -> Dict[str, Any]:
+        """Sample absolute object asset properties for each bucket and asset."""
+
+        def sample_range(value_range):
+            if value_range is None:
+                return None
+            return (
+                torch.rand(num_samples, num_assets, device=device)
+                * (value_range[1] - value_range[0])
+                + value_range[0]
+            )
+
+        center_of_mass = None
+        if self.center_of_mass_range is not None:
+            center_of_mass = torch.zeros(
+                num_samples, num_assets, 3, device=device, dtype=torch.float
+            )
+            for axis_idx, axis in enumerate(("x", "y", "z")):
+                value_range = self.center_of_mass_range.get(axis)
+                if value_range is None:
+                    continue
+                center_of_mass[..., axis_idx] = (
+                    torch.rand(num_samples, num_assets, device=device)
+                    * (value_range[1] - value_range[0])
+                    + value_range[0]
+                )
+
+        return {
+            "static_friction": sample_range(self.static_friction_range),
+            "dynamic_friction": sample_range(self.dynamic_friction_range),
+            "restitution": sample_range(self.restitution_range),
+            "mass": sample_range(self.mass_range),
+            "density": sample_range(self.density_range),
+            "center_of_mass": center_of_mass,
+        }
+
+
+@dataclass
 class CenterOfMassDomainRandomizationConfig:
     """Configuration for center of mass domain randomization."""
 
@@ -402,6 +528,10 @@ class DomainRandomizationConfig:
     )
     center_of_mass: Optional[CenterOfMassDomainRandomizationConfig] = field(
         default=None, metadata={"help": "Center of mass randomization configuration."}
+    )
+    object_assets: Optional[ObjectAssetDomainRandomizationConfig] = field(
+        default=None,
+        metadata={"help": "Scene object asset property randomization configuration."},
     )
     observation_noise: Optional[RobotNoiseConfig] = field(
         default=None,

--- a/protomotions/simulator/base_simulator/simulator.py
+++ b/protomotions/simulator/base_simulator/simulator.py
@@ -58,6 +58,7 @@ from protomotions.simulator.base_simulator.config import (
     SimBodyOrdering,
     ActionNoiseDomainRandomizationConfig,
     FrictionDomainRandomizationConfig,
+    ObjectAssetDomainRandomizationConfig,
     CenterOfMassDomainRandomizationConfig,
     ProjectileConfig,
     get_matching_indices,
@@ -1269,6 +1270,12 @@ class Simulator(RecordingMixin, ABC):
                     self.config.domain_randomization.center_of_mass
                 )
             )
+        if self.config.domain_randomization.object_assets is not None:
+            domain_randomization_dict["object_assets"] = (
+                self._process_object_asset_domain_randomization(
+                    self.config.domain_randomization.object_assets
+                )
+            )
 
         return domain_randomization_dict
 
@@ -1381,6 +1388,105 @@ class Simulator(RecordingMixin, ABC):
 
         com_dict = {"body_indices": body_indices, "com": com}
         return com_dict
+
+    def _process_object_asset_domain_randomization(
+        self, domain_randomization: ObjectAssetDomainRandomizationConfig
+    ) -> Dict[str, Any]:
+        """Sample absolute randomized properties for unique scene object assets."""
+        if self.scene_lib.num_scenes() == 0:
+            return None
+
+        asset_ids = sorted(
+            {
+                obj.first_instance_id
+                for scene in self.scene_lib.scenes
+                for obj in scene.objects
+            }
+        )
+        num_assets = len(asset_ids)
+        num_samples = min(self.num_envs, domain_randomization.num_buckets)
+        samples = domain_randomization.sample(num_samples, num_assets)
+
+        return {
+            "asset_ids": asset_ids,
+            "asset_id_to_column": {
+                asset_id: column for column, asset_id in enumerate(asset_ids)
+            },
+            "bucket_ids": torch.arange(self.num_envs, dtype=torch.long) % num_samples,
+            "num_buckets": num_samples,
+            **samples,
+        }
+
+    def _get_object_options_for_randomized_asset(
+        self,
+        obj,
+        env_id: Optional[int] = None,
+        bucket_id: Optional[int] = None,
+    ):
+        """Return object options with object-asset DR overrides applied."""
+        if self._domain_randomization is None:
+            return obj.options
+        object_dr = self._domain_randomization.get("object_assets")
+        if object_dr is None:
+            return obj.options
+
+        column = object_dr["asset_id_to_column"].get(obj.first_instance_id)
+        if column is None:
+            return obj.options
+
+        if bucket_id is None:
+            if env_id is None:
+                raise ValueError("env_id or bucket_id is required for object asset DR.")
+            bucket_id = int(object_dr["bucket_ids"][env_id].item())
+
+        overrides = {}
+        for field_name in (
+            "static_friction",
+            "dynamic_friction",
+            "restitution",
+            "mass",
+            "density",
+        ):
+            values = object_dr[field_name]
+            if values is not None:
+                overrides[field_name] = float(values[bucket_id, column].item())
+
+        if not overrides:
+            return obj.options
+        return obj.options.with_asset_property_overrides(overrides)
+
+    def _get_object_center_of_mass_for_randomized_asset(
+        self,
+        obj,
+        env_id: Optional[int] = None,
+        bucket_id: Optional[int] = None,
+    ) -> Optional[torch.Tensor]:
+        """Return absolute local CoM sampled for an object asset, if configured."""
+        if self._domain_randomization is None:
+            return None
+        object_dr = self._domain_randomization.get("object_assets")
+        if object_dr is None or object_dr.get("center_of_mass") is None:
+            return None
+
+        column = object_dr["asset_id_to_column"].get(obj.first_instance_id)
+        if column is None:
+            return None
+
+        if bucket_id is None:
+            if env_id is None:
+                raise ValueError("env_id or bucket_id is required for object asset DR.")
+            bucket_id = int(object_dr["bucket_ids"][env_id].item())
+
+        return object_dr["center_of_mass"][bucket_id, column]
+
+    def _num_object_asset_randomization_buckets(self) -> int:
+        """Return number of object asset DR buckets, or one when disabled."""
+        if self._domain_randomization is None:
+            return 1
+        object_dr = self._domain_randomization.get("object_assets")
+        if object_dr is None:
+            return 1
+        return object_dr["num_buckets"]
 
     # -------------------------
     # 🎨 Group 6: Rendering & Visualization (abstract methods only)

--- a/protomotions/simulator/isaacgym/simulator.py
+++ b/protomotions/simulator/isaacgym/simulator.py
@@ -536,11 +536,15 @@ class IsaacGymSimulator(Simulator):
     def _load_object_assets(self) -> None:
         if self.scene_lib.num_scenes() > 0:
             self._object_names = []
+            num_asset_buckets = self._num_object_asset_randomization_buckets()
 
             # Count assets
             asset_count = sum(
-                1 for scene in self.scene_lib.scenes for obj in scene.objects
-            )
+                1
+                for scene in self.scene_lib.scenes
+                for obj in scene.objects
+                if obj.is_first_instance
+            ) * num_asset_buckets
 
             with Progress() as progress:
                 task = progress.add_task(
@@ -553,55 +557,75 @@ class IsaacGymSimulator(Simulator):
                     for obj in scene.objects:
                         # Skip if we've already processed this object type
                         if not obj.is_first_instance:
-                            progress.update(task, advance=1)
                             continue
 
                         first_object_id = obj.first_instance_id
-                        if isinstance(obj, PrimitiveSceneObject):
-                            # Handle primitive shapes by creating temporary URDFs
-                            urdf_path = self._create_primitive_urdf(obj)
-                            object_name = os.path.splitext(os.path.basename(urdf_path))[
-                                0
-                            ]
-                            asset_path = urdf_path
-                        else:
-                            # Handle mesh objects
-                            assert isinstance(obj, MeshSceneObject)
-                            object_name = os.path.splitext(
-                                os.path.basename(obj.object_path)
-                            )[0]
-                            asset_path = obj.object_path
+                        for bucket_id in range(num_asset_buckets):
+                            object_options = (
+                                self._get_object_options_for_randomized_asset(
+                                    obj, bucket_id=bucket_id
+                                )
+                            )
+                            if isinstance(obj, PrimitiveSceneObject):
+                                # Handle primitive shapes by creating temporary URDFs
+                                urdf_path = self._create_primitive_urdf(
+                                    obj,
+                                    options=object_options,
+                                    variant_id=bucket_id
+                                    if num_asset_buckets > 1
+                                    else None,
+                                )
+                                object_name = os.path.splitext(
+                                    os.path.basename(urdf_path)
+                                )[0]
+                                asset_path = urdf_path
+                            else:
+                                # Handle mesh objects
+                                assert isinstance(obj, MeshSceneObject)
+                                object_name = os.path.splitext(
+                                    os.path.basename(obj.object_path)
+                                )[0]
+                                asset_path = obj.object_path
 
-                        asset_root = os.path.dirname(asset_path)
-                        asset_file = os.path.basename(asset_path)
+                            asset_root = os.path.dirname(asset_path)
+                            asset_file = os.path.basename(asset_path)
 
-                        # Create asset options
-                        object_asset_options = self._create_asset_options(obj)
+                            # Create asset options
+                            object_asset_options = self._create_asset_options(
+                                obj, options=object_options
+                            )
 
-                        # Load object asset and store in dictionary
-                        object_asset = self._gym.load_asset(
-                            self._sim, asset_root, asset_file, object_asset_options
-                        )
+                            # Load object asset and store in dictionary
+                            object_asset = self._gym.load_asset(
+                                self._sim, asset_root, asset_file, object_asset_options
+                            )
+                            self._apply_object_material_properties_to_asset(
+                                object_asset, object_options
+                            )
 
-                        # Add force sensor - common for both types
-                        sensor_pose = gymapi.Transform()
-                        sensor_options = gymapi.ForceSensorProperties()
-                        sensor_options.enable_forward_dynamics_forces = False
-                        sensor_options.enable_constraint_solver_forces = True
-                        sensor_options.use_world_frame = False
-                        self._gym.create_asset_force_sensor(
-                            object_asset, 0, sensor_pose, sensor_options
-                        )
-                        self._object_names.append(object_name)
-                        self._object_assets[first_object_id] = object_asset
+                            # Add force sensor - common for both types
+                            sensor_pose = gymapi.Transform()
+                            sensor_options = gymapi.ForceSensorProperties()
+                            sensor_options.enable_forward_dynamics_forces = False
+                            sensor_options.enable_constraint_solver_forces = True
+                            sensor_options.use_world_frame = False
+                            self._gym.create_asset_force_sensor(
+                                object_asset, 0, sensor_pose, sensor_options
+                            )
+                            self._object_names.append(object_name)
+                            self._object_assets[
+                                self._object_asset_key(first_object_id, bucket_id)
+                            ] = object_asset
 
-                        progress.update(task, advance=1)
+                            progress.update(task, advance=1)
 
             print(
-                f"=========== Total number of unique objects is {len(self._object_assets)}"
+                f"=========== Total number of object asset variants is {len(self._object_assets)}"
             )
 
-    def _create_asset_options(self, obj: SceneObject) -> gymapi.AssetOptions:
+    def _create_asset_options(
+        self, obj: SceneObject, options=None
+    ) -> gymapi.AssetOptions:
         """
         Create asset options for an object based on its configuration.
 
@@ -613,14 +637,17 @@ class IsaacGymSimulator(Simulator):
         """
         object_asset_options = gymapi.AssetOptions()
         object_asset_options.default_dof_drive_mode = gymapi.DOF_MODE_NONE
-        object_options_dict = obj.options.to_dict()
+        options = options or obj.options
+        object_options_dict = options.to_dict()
 
         # Without override_inertia the URDF's placeholder <inertial>
         # block takes precedence over AssetOptions.density.
-        if isinstance(obj, PrimitiveSceneObject) and obj.options.mass is None:
+        if isinstance(obj, PrimitiveSceneObject) and options.mass is None:
             object_asset_options.override_inertia = True
 
         object_options_dict.pop("mass", None)
+        for key in options.physics_material_kwargs():
+            object_options_dict.pop(key, None)
 
         if object_options_dict.get("vhacd_enabled", False):
             object_asset_options.vhacd_params = gymapi.VhacdParams()
@@ -644,7 +671,40 @@ class IsaacGymSimulator(Simulator):
                     print(f"Warning: {key} is not a valid option for object asset")
         return object_asset_options
 
-    def _create_primitive_urdf(self, obj: PrimitiveSceneObject) -> str:
+    def _apply_object_material_properties_to_asset(self, asset, options) -> None:
+        """Apply object material options to IsaacGym asset shape properties."""
+        material_kwargs = options.single_friction_material_kwargs()
+        if not material_kwargs:
+            return
+
+        shape_props = self._gym.get_asset_rigid_shape_properties(asset)
+        for shape_prop in shape_props:
+            if "friction" in material_kwargs:
+                shape_prop.friction = material_kwargs["friction"]
+            if "restitution" in material_kwargs:
+                shape_prop.restitution = material_kwargs["restitution"]
+        self._gym.set_asset_rigid_shape_properties(asset, shape_props)
+
+    def _object_asset_key(self, first_object_id: int, bucket_id: int):
+        if self._num_object_asset_randomization_buckets() == 1:
+            return first_object_id
+        return (first_object_id, bucket_id)
+
+    def _get_object_asset_for_env(self, env_id: int, obj: SceneObject):
+        bucket_id = 0
+        if self._domain_randomization is not None:
+            object_dr = self._domain_randomization.get("object_assets")
+            if object_dr is not None:
+                bucket_id = int(object_dr["bucket_ids"][env_id].item())
+        asset_key = self._object_asset_key(obj.first_instance_id, bucket_id)
+        return self._object_assets[asset_key]
+
+    def _create_primitive_urdf(
+        self,
+        obj: PrimitiveSceneObject,
+        options=None,
+        variant_id: Optional[int] = None,
+    ) -> str:
         """
         Create a URDF file for a primitive shape.
 
@@ -658,7 +718,9 @@ class IsaacGymSimulator(Simulator):
         temp_dir = self._temp_dir.name
 
         # Generate a unique filename based on the primitive ID
-        urdf_filename = f"{obj.object_identifier}.urdf"
+        options = options or obj.options
+        variant_suffix = "" if variant_id is None else f"_bucket_{variant_id}"
+        urdf_filename = f"{obj.object_identifier}{variant_suffix}.urdf"
         urdf_path = os.path.join(temp_dir, urdf_filename)
 
         # Skip if the file already exists
@@ -679,7 +741,7 @@ class IsaacGymSimulator(Simulator):
         else:
             raise ValueError(f"Unsupported primitive shape: {obj.object_identifier}")
 
-        mass_value = obj.options.mass if obj.options.mass is not None else 1.0
+        mass_value = options.mass if options.mass is not None else 1.0
 
         # Create the URDF XML content
         urdf_content = f"""<?xml version="1.0"?>
@@ -823,7 +885,7 @@ class IsaacGymSimulator(Simulator):
         # Objects spawned at scene offset (x,y) with z=0 - actual positions set via reset_envs()
         for obj_idx, obj in enumerate(scene.objects):
             # Get the asset directly using first_instance_id
-            object_asset = self._object_assets[obj.first_instance_id]
+            object_asset = self._get_object_asset_for_env(env_id, obj)
 
             # Spawn at scene offset to avoid collision, actual pose set via reset
             object_pose = gymapi.Transform()
@@ -840,6 +902,9 @@ class IsaacGymSimulator(Simulator):
                 col_group,
                 col_filter,
                 segmentation_id,
+            )
+            self._apply_object_body_properties_to_actor(
+                env_ptr, object_handle, obj, env_id
             )
 
             # Store handle and index for this object
@@ -867,6 +932,36 @@ class IsaacGymSimulator(Simulator):
                 texture_path = obj.options.to_dict().get("texture_path")
                 if texture_path and not self.headless:
                     self._apply_texture_to_object(env_ptr, object_handle, texture_path)
+
+    def _apply_object_body_properties_to_actor(
+        self, env_ptr, object_handle, obj: SceneObject, env_id: int
+    ) -> None:
+        """Apply object mass and COM properties that require an actor handle."""
+        options = self._get_object_options_for_randomized_asset(obj, env_id=env_id)
+        center_of_mass = self._get_object_center_of_mass_for_randomized_asset(
+            obj, env_id=env_id
+        )
+        if options.mass is None and center_of_mass is None:
+            return
+
+        body_props = self._gym.get_actor_rigid_body_properties(env_ptr, object_handle)
+        body_prop = body_props[0]
+
+        if options.mass is not None:
+            old_mass = body_prop.mass
+            if old_mass > 0:
+                self._scale_body_inertia(body_prop, options.mass / old_mass)
+            body_prop.mass = options.mass
+
+        if center_of_mass is not None:
+            new_com = center_of_mass.cpu().numpy().tolist()
+            current_com = [body_prop.com.x, body_prop.com.y, body_prop.com.z]
+            offset = [new_com[i] - current_com[i] for i in range(3)]
+            self._update_body_com_and_inertia(body_prop, offset)
+
+        self._gym.set_actor_rigid_body_properties(
+            env_ptr, object_handle, body_props, recomputeInertia=False
+        )
 
     def _build_projectile_actors(self, env_id: int, env_ptr) -> None:
         """Create projectile box actors for one environment.
@@ -1420,6 +1515,13 @@ class IsaacGymSimulator(Simulator):
         num_buckets = len(self._humanoid_assets_for_friction)
         bucket_id = env_id % num_buckets
         return self._humanoid_assets_for_friction[bucket_id]
+
+    def _scale_body_inertia(self, body_prop, scale: float) -> None:
+        """Scale a single rigid body's inertia matrix in place."""
+        for row in ("x", "y", "z"):
+            row_vec = getattr(body_prop.inertia, row)
+            for col in ("x", "y", "z"):
+                setattr(row_vec, col, getattr(row_vec, col) * scale)
 
     def _update_body_com_and_inertia(self, body_prop, offset: List[float]) -> None:
         """

--- a/protomotions/simulator/isaaclab/simulator.py
+++ b/protomotions/simulator/isaaclab/simulator.py
@@ -210,9 +210,12 @@ class IsaacLabSimulator(Simulator):
 
         for env_id, scene in enumerate(self.scene_lib.scenes):
             for obj_idx, obj in enumerate(scene.objects):
+                object_options = self._get_object_options_for_randomized_asset(
+                    obj, env_id=env_id
+                )
                 # Common properties based on object options
                 rigid_props = sim_utils.RigidBodyPropertiesCfg(
-                    kinematic_enabled=obj.options.fix_base_link,
+                    kinematic_enabled=object_options.fix_base_link,
                 )
                 collision_props = sim_utils.CollisionPropertiesCfg(
                     contact_offset=0.002,
@@ -220,7 +223,9 @@ class IsaacLabSimulator(Simulator):
                 )
 
                 # Resolve color: use object option if set, else per-type default
-                obj_color = obj.options.color if obj.options.color is not None else None
+                obj_color = (
+                    object_options.color if object_options.color is not None else None
+                )
 
                 # Handle different object types
                 if isinstance(obj, MeshSceneObject):
@@ -230,10 +235,12 @@ class IsaacLabSimulator(Simulator):
                     asset_path = Path(
                         os.path.join(main_dir_path, obj.object_path)
                     ).resolve()
+                    mass_props = self._mass_props_from_options(object_options)
 
                     spawn_cfg = sim_utils.UsdFileCfg(
                         usd_path=str(asset_path),
                         rigid_props=rigid_props,
+                        mass_props=mass_props,
                         collision_props=collision_props,
                         visual_material=sim_utils.PreviewSurfaceCfg(
                             diffuse_color=obj_color or (0.2, 0.7, 0.3),
@@ -241,7 +248,7 @@ class IsaacLabSimulator(Simulator):
                         ),
                     )
                 elif isinstance(obj, BoxSceneObject):
-                    mass_props = self._mass_props_from_options(obj.options)
+                    mass_props = self._mass_props_from_options(object_options)
                     spawn_cfg = sim_utils.CuboidCfg(
                         size=(obj.width, obj.depth, obj.height),
                         visual_material=sim_utils.PreviewSurfaceCfg(
@@ -253,7 +260,7 @@ class IsaacLabSimulator(Simulator):
                         collision_props=collision_props,
                     )
                 elif isinstance(obj, SphereSceneObject):
-                    mass_props = self._mass_props_from_options(obj.options)
+                    mass_props = self._mass_props_from_options(object_options)
                     spawn_cfg = sim_utils.SphereCfg(
                         radius=obj.radius,
                         visual_material=sim_utils.PreviewSurfaceCfg(
@@ -265,7 +272,7 @@ class IsaacLabSimulator(Simulator):
                         collision_props=collision_props,
                     )
                 elif isinstance(obj, CylinderSceneObject):
-                    mass_props = self._mass_props_from_options(obj.options)
+                    mass_props = self._mass_props_from_options(object_options)
                     spawn_cfg = sim_utils.CylinderCfg(
                         radius=obj.radius,
                         height=obj.height,
@@ -461,8 +468,76 @@ class IsaacLabSimulator(Simulator):
                 :, self._domain_randomization["center_of_mass"]["body_indices"], :3
             ] += self._domain_randomization["center_of_mass"]["com"].to(coms.device)
 
-            # Set the new comsfa
+            # Set the new COMs.
             self._robot.root_physx_view.set_coms(coms, all_env_ids)
+
+        self._apply_scene_object_properties_after_spawn(all_env_ids)
+
+    def _apply_scene_object_properties_after_spawn(
+        self, all_env_ids: torch.Tensor
+    ) -> None:
+        """Apply scene object properties that require live PhysX views.
+
+        IsaacLab USD spawners do not accept per-asset physics materials, so this
+        runtime path is the source of truth for scene object material overrides.
+        """
+        if self.scene_lib.num_scenes() == 0:
+            return
+        object_dr = (
+            self._domain_randomization.get("object_assets")
+            if self._domain_randomization is not None
+            else None
+        )
+        apply_center_of_mass = (
+            object_dr is not None and object_dr.get("center_of_mass") is not None
+        )
+
+        for obj_idx, object_view in enumerate(self._object):
+            materials = None
+            coms = (
+                object_view.root_physx_view.get_coms().clone()
+                if apply_center_of_mass
+                else None
+            )
+            for env_id, scene in enumerate(self.scene_lib.scenes):
+                object_options = self._get_object_options_for_randomized_asset(
+                    scene.objects[obj_idx], env_id=env_id
+                )
+                material_kwargs = object_options.physics_material_kwargs()
+                if material_kwargs:
+                    if materials is None:
+                        materials = (
+                            object_view.root_physx_view.get_material_properties()
+                            .clone()
+                            .to("cpu")
+                        )
+                    if "static_friction" in material_kwargs:
+                        materials[env_id, :, 0] = material_kwargs["static_friction"]
+                    if "dynamic_friction" in material_kwargs:
+                        materials[env_id, :, 1] = material_kwargs["dynamic_friction"]
+                    if "restitution" in material_kwargs:
+                        materials[env_id, :, 2] = material_kwargs["restitution"]
+
+                if not apply_center_of_mass:
+                    continue
+                center_of_mass = self._get_object_center_of_mass_for_randomized_asset(
+                    scene.objects[obj_idx], env_id=env_id
+                )
+                if center_of_mass is None:
+                    continue
+
+                center_of_mass = center_of_mass.to(coms.device)
+                if coms.ndim == 2:
+                    coms[env_id, :3] = center_of_mass
+                else:
+                    coms[env_id, 0, :3] = center_of_mass
+
+            if materials is not None:
+                object_view.root_physx_view.set_material_properties(
+                    materials, indices=all_env_ids
+                )
+            if apply_center_of_mass:
+                object_view.root_physx_view.set_coms(coms, all_env_ids)
 
     # =====================================================
     # Group 3: Simulation Steps & State Management

--- a/protomotions/tests/test_object_asset_domain_randomization.py
+++ b/protomotions/tests/test_object_asset_domain_randomization.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The ProtoMotions Developers
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import torch
+
+from protomotions.components.scene_lib import ObjectOptions
+from protomotions.simulator.base_simulator.config import (
+    DomainRandomizationConfig,
+    ObjectAssetDomainRandomizationConfig,
+)
+from protomotions.simulator.base_simulator.simulator import Simulator
+
+
+def test_object_asset_dr_config_samples_absolute_ranges_per_asset():
+    cfg = ObjectAssetDomainRandomizationConfig(
+        num_buckets=4,
+        static_friction_range=(0.2, 0.4),
+        restitution_range=(0.0, 0.2),
+        mass_range=(1.0, 2.0),
+        center_of_mass_range={"x": (-0.05, 0.05), "z": (0.1, 0.2)},
+    )
+
+    samples = cfg.sample(num_samples=3, num_assets=2)
+
+    assert samples["static_friction"].shape == (3, 2)
+    assert samples["static_friction"].min() >= 0.2
+    assert samples["static_friction"].max() <= 0.4
+    assert samples["restitution"].shape == (3, 2)
+    assert samples["mass"].shape == (3, 2)
+    assert samples["center_of_mass"].shape == (3, 2, 3)
+    assert samples["center_of_mass"][..., 0].min() >= -0.05
+    assert samples["center_of_mass"][..., 0].max() <= 0.05
+    assert torch.all(samples["center_of_mass"][..., 1] == 0.0)
+    assert samples["center_of_mass"][..., 2].min() >= 0.1
+    assert samples["center_of_mass"][..., 2].max() <= 0.2
+    assert samples["dynamic_friction"] is None
+
+
+def test_object_asset_dr_is_part_of_domain_randomization_config():
+    cfg = ObjectAssetDomainRandomizationConfig(static_friction_range=(0.2, 0.4))
+
+    assert DomainRandomizationConfig(object_assets=cfg).object_assets is cfg
+
+
+def test_object_asset_dr_rejects_mass_and_density_together():
+    try:
+        ObjectAssetDomainRandomizationConfig(
+            mass_range=(1.0, 2.0),
+            density_range=(100.0, 200.0),
+        )
+    except ValueError as exc:
+        assert "mass_range" in str(exc)
+        assert "density_range" in str(exc)
+    else:
+        raise AssertionError("Expected mass_range and density_range to be exclusive")
+
+
+def test_object_options_overrides_do_not_mutate_scene_defaults():
+    base_options = ObjectOptions(
+        density=1000.0,
+        static_friction=0.5,
+        restitution=0.0,
+    )
+
+    randomized = base_options.with_asset_property_overrides(
+        {
+            "mass": 2.0,
+            "static_friction": 0.8,
+            "dynamic_friction": 0.7,
+            "restitution": 0.1,
+        }
+    )
+
+    assert randomized.mass == 2.0
+    assert randomized.density is None
+    assert randomized.static_friction == 0.8
+    assert randomized.dynamic_friction == 0.7
+    assert randomized.restitution == 0.1
+    assert base_options.mass is None
+    assert base_options.density == 1000.0
+    assert base_options.static_friction == 0.5
+
+
+def test_simulator_object_asset_dr_overrides_by_bucket():
+    obj = SimpleNamespace(
+        first_instance_id=3,
+        options=ObjectOptions(mass=1.0, static_friction=0.5, restitution=0.0),
+    )
+    simulator = SimpleNamespace(
+        _domain_randomization={
+            "object_assets": {
+                "asset_id_to_column": {3: 0},
+                "bucket_ids": torch.tensor([1]),
+                "static_friction": torch.tensor([[0.2], [0.8]]),
+                "dynamic_friction": None,
+                "restitution": torch.tensor([[0.0], [0.1]]),
+                "mass": torch.tensor([[1.0], [2.0]]),
+                "density": None,
+                "center_of_mass": torch.tensor(
+                    [[[0.0, 0.0, 0.0]], [[0.1, 0.2, 0.3]]]
+                ),
+            }
+        }
+    )
+
+    randomized = Simulator._get_object_options_for_randomized_asset(
+        simulator, obj, env_id=0
+    )
+
+    assert randomized.mass == 2.0
+    assert randomized.density is None
+    assert abs(randomized.static_friction - 0.8) < 1e-6
+    assert abs(randomized.restitution - 0.1) < 1e-6
+    assert obj.options.mass == 1.0
+
+    center_of_mass = Simulator._get_object_center_of_mass_for_randomized_asset(
+        simulator, obj, env_id=0
+    )
+    assert torch.allclose(center_of_mass, torch.tensor([0.1, 0.2, 0.3]))

--- a/protomotions/tests/test_scene_object_options.py
+++ b/protomotions/tests/test_scene_object_options.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The ProtoMotions Developers
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from protomotions.components.scene_lib import ObjectOptions
+
+
+def test_object_options_exposes_optional_material_properties():
+    options = ObjectOptions(
+        static_friction=1.2,
+        dynamic_friction=0.9,
+        restitution=0.05,
+    )
+
+    assert options.physics_material_kwargs() == {
+        "static_friction": 1.2,
+        "dynamic_friction": 0.9,
+        "restitution": 0.05,
+    }
+    assert options.to_dict()["static_friction"] == 1.2
+
+
+def test_object_options_omits_material_properties_by_default():
+    options = ObjectOptions()
+
+    assert options.physics_material_kwargs() == {}
+    assert "static_friction" not in options.to_dict()
+
+
+def test_object_options_single_friction_prefers_static_friction():
+    options = ObjectOptions(static_friction=1.2, dynamic_friction=0.9)
+
+    assert options.single_friction() == 1.2
+    assert ObjectOptions(dynamic_friction=0.9).single_friction() == 0.9
+
+
+def test_object_options_exposes_single_friction_backend_material_properties():
+    options = ObjectOptions(
+        static_friction=1.2,
+        dynamic_friction=0.9,
+        restitution=0.05,
+    )
+
+    assert options.single_friction_material_kwargs() == {
+        "friction": 1.2,
+        "restitution": 0.05,
+    }
+    assert ObjectOptions(dynamic_friction=0.9).single_friction_material_kwargs(
+        friction_key="mu"
+    ) == {"mu": 0.9}


### PR DESCRIPTION
## What changed

This adds scene object asset randomization for issue #218.

SceneLib object options now support base physical properties for mesh and primitive scene objects:
- mass or density, with the two kept mutually exclusive
- static friction, dynamic friction, and restitution

Domain randomization now supports absolute object asset ranges for:
- static_friction_range
- dynamic_friction_range
- restitution_range
- mass_range or density_range
- center_of_mass_range as an absolute local center-of-mass value

The object asset ranges are global for scene objects. They are not per-asset configs and they are not additive or multiplicative offsets. Sampled values replace the scene-lib base property for that bucket.

IsaacLab and IsaacGym support these properties for primitive and mesh scene objects. Newton currently does not spawn scene-lib objects, so object asset randomization is documented as a no-op there.

## How to run it

Set base properties in SceneLib with ObjectOptions, for example:

    ObjectOptions(density=1000.0, static_friction=0.8, dynamic_friction=0.6, restitution=0.0)

Enable randomization through DomainRandomizationConfig:

    DomainRandomizationConfig(
        object_assets=ObjectAssetDomainRandomizationConfig(
            num_buckets=32,
            static_friction_range=(0.4, 1.4),
            dynamic_friction_range=(0.3, 1.0),
            restitution_range=(0.0, 0.2),
            mass_range=(0.5, 3.0),
            center_of_mass_range={"x": (-0.05, 0.05), "y": (-0.02, 0.02), "z": (0.0, 0.10)},
        )
    )

Use mass_range or density_range, not both. Omitted center_of_mass_range axes default to 0.0.