### PR TITLE
fix: isolate hidden projectiles and disable training pool by default

### DIFF
--- a/protomotions/simulator/base_simulator/config.py
+++ b/protomotions/simulator/base_simulator/config.py
@@ -489,6 +489,7 @@ class ProjectileConfig:
     direction_noise_std: float = 0.1  # std of Gaussian noise added to aim direction
     hide_delay: float = 2.0  # seconds before cube disappears
     hide_z: float = -2.0  # z-position when hidden
+    hide_spacing: float = 4.0  # z-spacing between hidden projectile slots
 
     def get_sizes(self) -> list:
         """Return per-pool-index half sizes, linearly interpolated."""
@@ -497,6 +498,10 @@ class ProjectileConfig:
         if n == 1:
             return [lo]
         return [lo + (hi - lo) * i / (n - 1) for i in range(n)]
+
+    def hidden_z_for_index(self, projectile_index: int) -> float:
+        """Return a hidden z-position that avoids projectile-projectile overlap."""
+        return self.hide_z - self.hide_spacing * projectile_index
 
 
 @dataclass

--- a/protomotions/simulator/base_simulator/config.py
+++ b/protomotions/simulator/base_simulator/config.py
@@ -477,7 +477,7 @@ class PushDomainRandomizationConfig:
 class ProjectileConfig:
     """Configuration for projectile cube throwing (J-key perturbation)."""
 
-    num_projectiles: int = 5
+    num_projectiles: int = 0
     cube_half_size_range: Tuple[float, float] = (0.05, 0.15)  # per-pool-index size
     density: float = 500.0  # kg/m^3
     speed_range: Tuple[float, float] = (30.0, 40.0)  # m/s (ASE uses 30-40)
@@ -588,7 +588,7 @@ class SimulatorConfig:
         metadata={
             "help": (
                 "Projectile cube perturbation configuration (J-key throws). "
-                "Set num_projectiles=0 to disable projectiles."
+                "Training defaults to no projectiles; inference enables one."
             )
         },
     )

--- a/protomotions/simulator/base_simulator/simulator.py
+++ b/protomotions/simulator/base_simulator/simulator.py
@@ -436,6 +436,8 @@ class Simulator(RecordingMixin, ABC):
         3. Lead the target by adding robot XY velocity to launch velocity
         """
         cfg = self._proj_config
+        if cfg.num_projectiles == 0:
+            return
         all_env_ids = torch.arange(self.num_envs, device=self.device)
         cube_idx = self._proj_next_idx.clone()
 
@@ -498,6 +500,9 @@ class Simulator(RecordingMixin, ABC):
         env_indices, proj_indices = torch.where(expired_mask)
         hide_pos = torch.zeros(len(env_indices), 3, device=self.device)
         hide_pos[:, 2] = self._proj_config.hide_z
+        hide_pos[:, 2] -= self._proj_config.hide_spacing * proj_indices.to(
+            hide_pos.dtype
+        )
         zero_rot = torch.zeros(len(env_indices), 4, device=self.device)
         zero_rot[:, 3] = 1.0
         zero_vel = torch.zeros(len(env_indices), 3, device=self.device)
@@ -542,6 +547,9 @@ class Simulator(RecordingMixin, ABC):
         hide_pos = torch.zeros(len(env_expanded), 3, device=self.device)
         hide_pos[:, 0] = env_expanded.float() * float(N) + proj_expanded.float()
         hide_pos[:, 2] = self._proj_config.hide_z
+        hide_pos[:, 2] -= self._proj_config.hide_spacing * proj_expanded.to(
+            hide_pos.dtype
+        )
         zero_rot = torch.zeros(len(env_expanded), 4, device=self.device)
         zero_rot[:, 3] = 1.0
         zero_vel = torch.zeros(len(env_expanded), 3, device=self.device)

--- a/protomotions/simulator/base_simulator/simulator.py
+++ b/protomotions/simulator/base_simulator/simulator.py
@@ -425,7 +425,8 @@ class Simulator(RecordingMixin, ABC):
         self._proj_sim_time = torch.zeros(self.num_envs, device=self.device)
 
         self._create_projectiles(self._proj_config)
-        self._hide_all_projectiles()
+        if N > 0:
+            self._hide_all_projectiles()
 
     def _throw_projectile(self) -> None:
         """J-key handler: launch next projectile cube at each robot.
@@ -499,6 +500,9 @@ class Simulator(RecordingMixin, ABC):
 
         env_indices, proj_indices = torch.where(expired_mask)
         hide_pos = torch.zeros(len(env_indices), 3, device=self.device)
+        hide_pos[:, 0] = env_indices.to(hide_pos.dtype) * float(
+            self._proj_config.num_projectiles
+        ) + proj_indices.to(hide_pos.dtype)
         hide_pos[:, 2] = self._proj_config.hide_z
         hide_pos[:, 2] -= self._proj_config.hide_spacing * proj_indices.to(
             hide_pos.dtype
@@ -517,7 +521,8 @@ class Simulator(RecordingMixin, ABC):
         self._proj_sim_time[env_ids] = 0.0
         self._proj_throw_time[env_ids] = float("-inf")
         self._proj_next_idx[env_ids] = 0
-        self._hide_projectiles_for_envs(env_ids)
+        if self._proj_config.num_projectiles > 0:
+            self._hide_projectiles_for_envs(env_ids)
 
     def _hide_all_projectiles(self) -> None:
         """Move all projectiles underground."""

--- a/protomotions/simulator/isaacgym/config.py
+++ b/protomotions/simulator/isaacgym/config.py
@@ -4,7 +4,11 @@
 """Configuration classes for IsaacGym simulator."""
 
 from dataclasses import dataclass, field
-from protomotions.simulator.base_simulator.config import SimParams, SimulatorConfig
+from protomotions.simulator.base_simulator.config import (
+    ProjectileConfig,
+    SimParams,
+    SimulatorConfig,
+)
 
 
 @dataclass
@@ -93,4 +97,13 @@ class IsaacGymSimulatorConfig(SimulatorConfig):
     sim: IsaacGymSimParams = field(
         default_factory=IsaacGymSimParams,
         metadata={"help": "IsaacGym-specific simulation parameters."}
+    )
+    projectile: ProjectileConfig = field(
+        # IsaacGym caps to a single projectile by default to stay under PhysX's
+        # ~80k maxRigidPatchCount budget against the wildcard-collidable
+        # add_triangle_mesh terrain. Override via
+        # --overrides simulator.projectile.num_projectiles=N to opt back into
+        # more cubes (e.g. for interactive viewer throws).
+        default_factory=lambda: ProjectileConfig(num_projectiles=1),
+        metadata={"help": "Projectile pool config (IsaacGym defaults to 1 cube)."},
     )

--- a/protomotions/simulator/isaacgym/config.py
+++ b/protomotions/simulator/isaacgym/config.py
@@ -5,7 +5,6 @@
 
 from dataclasses import dataclass, field
 from protomotions.simulator.base_simulator.config import (
-    ProjectileConfig,
     SimParams,
     SimulatorConfig,
 )
@@ -97,13 +96,4 @@ class IsaacGymSimulatorConfig(SimulatorConfig):
     sim: IsaacGymSimParams = field(
         default_factory=IsaacGymSimParams,
         metadata={"help": "IsaacGym-specific simulation parameters."}
-    )
-    projectile: ProjectileConfig = field(
-        # IsaacGym caps to a single projectile by default to stay under PhysX's
-        # ~80k maxRigidPatchCount budget against the wildcard-collidable
-        # add_triangle_mesh terrain. Override via
-        # --overrides simulator.projectile.num_projectiles=N to opt back into
-        # more cubes (e.g. for interactive viewer throws).
-        default_factory=lambda: ProjectileConfig(num_projectiles=1),
-        metadata={"help": "Projectile pool config (IsaacGym defaults to 1 cube)."},
     )

--- a/protomotions/simulator/isaacgym/simulator.py
+++ b/protomotions/simulator/isaacgym/simulator.py
@@ -110,7 +110,9 @@ class IsaacGymSimulator(Simulator):
         Called by base class _initialize_with_markers() after visualization markers
         are set. Creates simulation, viewer, and acquires tensors.
         """
-        # Scene construction below needs _proj_config before _init_projectiles runs
+        # Scene construction below needs _proj_config before _init_projectiles runs.
+        # The IsaacGym-specific default of 1 projectile (vs. 5 for other backends)
+        # comes from IsaacGymSimulatorConfig.projectile; see config.py for why.
         self._resolve_proj_config()
 
         # Update marker names ordering from visualization markers
@@ -980,7 +982,11 @@ class IsaacGymSimulator(Simulator):
 
         for proj_idx in range(self._proj_config.num_projectiles):
             start_pose = gymapi.Transform()
-            start_pose.p = gymapi.Vec3(0.0, 0.0, self._proj_config.hide_z)
+            start_pose.p = gymapi.Vec3(
+                env_id,
+                env_id,
+                self._proj_config.hidden_z_for_index(proj_idx),
+            )
             start_pose.r = gymapi.Quat(0.0, 0.0, 0.0, 1.0)
 
             handle = self._gym.create_actor(
@@ -1397,6 +1403,12 @@ class IsaacGymSimulator(Simulator):
         """Set root state for specific projectiles via indexed tensor API."""
         # IsaacGym uses wxyz quaternion format
         rot_wxyz = rotations_xyzw[:, [3, 0, 1, 2]]
+        positions = positions.clone()
+        hidden_mask = positions[:, 2] <= self._proj_config.hide_z
+        if hidden_mask.any():
+            hidden_env_offsets = env_ids[hidden_mask].to(positions.dtype)
+            positions[hidden_mask, 0] = hidden_env_offsets
+            positions[hidden_mask, 1] = hidden_env_offsets
 
         self._projectile_root_states[env_ids, proj_indices, 0:3] = positions
         self._projectile_root_states[env_ids, proj_indices, 3:7] = rot_wxyz

--- a/protomotions/simulator/isaaclab/simulator.py
+++ b/protomotions/simulator/isaaclab/simulator.py
@@ -964,6 +964,17 @@ class IsaacLabSimulator(Simulator):
         # IsaacLab uses wxyz quaternion format
         rot_wxyz = rotations_xyzw[:, [3, 0, 1, 2]]
 
+        # Match the IsaacGym backend: when a projectile is being "hidden" (its
+        # target z is at or below hide_z), spread it across the X/Y world plane
+        # by env_id so post-init projectile positions are consistent across
+        # simulators. Throws use z > hide_z and skip this branch.
+        positions = positions.clone()
+        hidden_mask = positions[:, 2] <= self._proj_config.hide_z
+        if hidden_mask.any():
+            hidden_env_offsets = env_ids[hidden_mask].to(positions.dtype)
+            positions[hidden_mask, 0] = hidden_env_offsets
+            positions[hidden_mask, 1] = hidden_env_offsets
+
         for pid in proj_indices.unique():
             mask = proj_indices == pid
             eids = env_ids[mask]

--- a/protomotions/simulator/isaaclab/utils/scene.py
+++ b/protomotions/simulator/isaaclab/utils/scene.py
@@ -121,7 +121,7 @@ class SceneCfg(InteractiveSceneCfg):
                         ),
                     ),
                     init_state=RigidObjectCfg.InitialStateCfg(
-                        pos=(0.0, 0.0, projectile_config.hide_z)
+                        pos=(0.0, 0.0, projectile_config.hidden_z_for_index(proj_idx))
                     ),
                 )
                 setattr(self, f"projectile_{proj_idx}", proj_cfg)

--- a/protomotions/simulator/isaaclab/utils/scene.py
+++ b/protomotions/simulator/isaaclab/utils/scene.py
@@ -121,7 +121,11 @@ class SceneCfg(InteractiveSceneCfg):
                         ),
                     ),
                     init_state=RigidObjectCfg.InitialStateCfg(
-                        pos=(0.0, 0.0, projectile_config.hidden_z_for_index(proj_idx))
+                        pos=(
+                            float(proj_idx),
+                            float(proj_idx),
+                            projectile_config.hidden_z_for_index(proj_idx),
+                        )
                     ),
                 )
                 setattr(self, f"projectile_{proj_idx}", proj_cfg)

--- a/protomotions/simulator/mujoco/simulator.py
+++ b/protomotions/simulator/mujoco/simulator.py
@@ -173,7 +173,7 @@ class MujocoSimulator(Simulator):
             s = str(sizes[i])
             body = ET.SubElement(worldbody, "body")
             body.set("name", f"projectile_{i}")
-            body.set("pos", f"0 0 {hide_z - hide_spacing * i}")
+            body.set("pos", f"{i} {i} {hide_z - hide_spacing * i}")
             joint = ET.SubElement(body, "joint")
             joint.set("type", "free")
             geom = ET.SubElement(body, "geom")

--- a/protomotions/simulator/mujoco/simulator.py
+++ b/protomotions/simulator/mujoco/simulator.py
@@ -136,6 +136,7 @@ class MujocoSimulator(Simulator):
                 projectile_config.get_sizes(),
                 projectile_config.density,
                 projectile_config.hide_z,
+                projectile_config.hide_spacing,
             )
 
         # Write cleaned XML to a temp file in the same directory
@@ -161,6 +162,7 @@ class MujocoSimulator(Simulator):
         sizes: list,
         density: float,
         hide_z: float,
+        hide_spacing: float,
     ) -> None:
         """Add free-joint box bodies for projectiles to the MJCF worldbody."""
         worldbody = root.find("worldbody")
@@ -171,7 +173,7 @@ class MujocoSimulator(Simulator):
             s = str(sizes[i])
             body = ET.SubElement(worldbody, "body")
             body.set("name", f"projectile_{i}")
-            body.set("pos", f"0 0 {hide_z}")
+            body.set("pos", f"0 0 {hide_z - hide_spacing * i}")
             joint = ET.SubElement(body, "joint")
             joint.set("type", "free")
             geom = ET.SubElement(body, "geom")

--- a/protomotions/simulator/newton/simulator.py
+++ b/protomotions/simulator/newton/simulator.py
@@ -211,7 +211,11 @@ class NewtonSimulator(Simulator):
         for i in range(self._proj_config.num_projectiles):
             s = proj_sizes[i]
             xform = wp.transform(
-                (0.0, 0.0, self._proj_config.hidden_z_for_index(i)),
+                (
+                    float(i),
+                    float(i),
+                    self._proj_config.hidden_z_for_index(i),
+                ),
                 (0.0, 0.0, 0.0, 1.0),
             )
             body = self.robot.add_body(xform=xform)

--- a/protomotions/simulator/newton/simulator.py
+++ b/protomotions/simulator/newton/simulator.py
@@ -211,7 +211,7 @@ class NewtonSimulator(Simulator):
         for i in range(self._proj_config.num_projectiles):
             s = proj_sizes[i]
             xform = wp.transform(
-                (0.0, 0.0, self._proj_config.hide_z),
+                (0.0, 0.0, self._proj_config.hidden_z_for_index(i)),
                 (0.0, 0.0, 0.0, 1.0),
             )
             body = self.robot.add_body(xform=xform)
@@ -1159,6 +1159,17 @@ class NewtonSimulator(Simulator):
 
         Newton uses xyzw quaternions natively — no conversion needed.
         """
+        # Match the IsaacGym backend: when a projectile is being "hidden" (its
+        # target z is at or below hide_z), spread it across the X/Y world plane
+        # by env_id so post-init projectile positions are consistent across
+        # simulators. Throws use z > hide_z and skip this branch.
+        positions = positions.clone()
+        hidden_mask = positions[:, 2] <= self._proj_config.hide_z
+        if hidden_mask.any():
+            hidden_env_offsets = env_ids[hidden_mask].to(positions.dtype)
+            positions[hidden_mask, 0] = hidden_env_offsets
+            positions[hidden_mask, 1] = hidden_env_offsets
+
         joint_q = wp.to_torch(self.state_0.joint_q)
         joint_qd = wp.to_torch(self.state_0.joint_qd)
 

--- a/protomotions/tests/test_projectile_defaults.py
+++ b/protomotions/tests/test_projectile_defaults.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+from protomotions.simulator.base_simulator.config import (
+    ProjectileConfig,
+    SimParams,
+    SimulatorConfig,
+)
+from protomotions.utils.inference_utils import apply_all_inference_overrides
+
+
+def test_projectiles_are_disabled_by_default_for_training():
+    assert ProjectileConfig().num_projectiles == 0
+
+
+def test_inference_overrides_enable_one_projectile_by_default():
+    simulator_config = SimulatorConfig(
+        _target_="test",
+        w_last=True,
+        headless=True,
+        num_envs=1,
+        sim=SimParams(),
+        experiment_name="test",
+        projectile=ProjectileConfig(num_projectiles=0),
+    )
+
+    apply_all_inference_overrides(
+        robot_config=None,
+        simulator_config=simulator_config,
+        env_config=None,
+        agent_config=None,
+        terrain_config=None,
+        motion_lib_config=None,
+        scene_lib_config=None,
+        args=SimpleNamespace(),
+    )
+
+    assert simulator_config.projectile.num_projectiles == 1

--- a/protomotions/utils/inference_utils.py
+++ b/protomotions/utils/inference_utils.py
@@ -41,6 +41,13 @@ def apply_all_inference_overrides(
         args: Optional command line arguments
     """
 
+    # Projectile perturbations are disabled during training by default. Enable
+    # one projectile for inference unless the experiment or CLI requested a
+    # specific pool size.
+    projectile_config = getattr(simulator_config, "projectile", None)
+    if projectile_config is not None and projectile_config.num_projectiles == 0:
+        projectile_config.num_projectiles = 1
+
     # Apply experiment-specific inference overrides if available
     if experiment_module is not None and args is not None:
         apply_inference_overrides_fn = getattr(


### PR DESCRIPTION
Fixes #222.

- Give hidden projectile slots distinct positions at creation and when they are reset or expire across IsaacGym, IsaacLab, Newton, and MuJoCo.
- Keep the shared hide_spacing / hidden_z_for_index() layout and guard the zero-projectile lifecycle, including the J-key path.
- Set ProjectileConfig.num_projectiles=0 for training by default, avoiding unnecessary rigid bodies and PhysX contact-patch pressure.
- Standard inference config generation enables one projectile only when the configured pool is zero; explicit experiment or CLI pool sizes remain unchanged.
- Remove the IsaacGym-only default so all backends share the same training and inference semantics.

Validation: focused projectile regression tests pass (2), all touched simulator files compile, and git diff --check is clean.