### PR TITLE
Preserve FPS metadata through retargeting

### DIFF
--- a/data/scripts/convert_pyroki_retargeted_robot_motions_to_proto.py
+++ b/data/scripts/convert_pyroki_retargeted_robot_motions_to_proto.py
@@ -31,6 +31,11 @@ from protomotions.components.pose_lib import (
 )
 from protomotions.robot_configs.factory import robot_config
 from motion_filter import passes_exclude_motion_filter
+from protomotions.utils.retargeting_fps import (
+    downsample_factor,
+    fps_from_mapping,
+    resolve_output_fps,
+)
 
 app = typer.Typer(pretty_exceptions_enable=False)
 
@@ -82,7 +87,9 @@ def process_csv_file(csv_path, input_fps, output_fps, device, dtype):
     # Extract joint angles (already in radians)
     joint_angles = data[:, 7:]
 
-    factor = input_fps // output_fps
+    actual_input_fps = float(input_fps)
+    actual_output_fps = resolve_output_fps(actual_input_fps, output_fps)
+    factor = downsample_factor(actual_input_fps, actual_output_fps)
     if factor > 1:
         joint_angles = joint_angles[::factor]
         root_pos = root_pos[::factor]
@@ -93,7 +100,7 @@ def process_csv_file(csv_path, input_fps, output_fps, device, dtype):
     root_rot_wxyz = torch.from_numpy(root_rot_wxyz).to(device, dtype)
     joint_angles = torch.from_numpy(joint_angles).to(device, dtype)
 
-    return root_pos, root_rot_wxyz, joint_angles
+    return root_pos, root_rot_wxyz, joint_angles, actual_output_fps
 
 
 def process_npz_file(npz_path, input_fps, output_fps, device, dtype):
@@ -109,8 +116,9 @@ def process_npz_file(npz_path, input_fps, output_fps, device, dtype):
         tuple: (root_pos, root_rot_wxyz, joint_angles)
     """
     data = np.load(npz_path, allow_pickle=True)
-
-    factor = input_fps // output_fps
+    actual_input_fps = fps_from_mapping(data, input_fps)
+    actual_output_fps = resolve_output_fps(actual_input_fps, output_fps)
+    factor = downsample_factor(actual_input_fps, actual_output_fps)
 
     # Extract and downsample the arrays (can't modify NpzFile in-place)
     base_frame_pos = data["base_frame_pos"][::factor]
@@ -121,7 +129,7 @@ def process_npz_file(npz_path, input_fps, output_fps, device, dtype):
     root_rot_wxyz = torch.from_numpy(base_frame_wxyz).to(device, dtype)
     joint_angles = torch.from_numpy(joint_angles).to(device, dtype)
 
-    return root_pos, root_rot_wxyz, joint_angles
+    return root_pos, root_rot_wxyz, joint_angles, actual_output_fps
 
 
 def apply_contact_labels_to_motion(
@@ -163,9 +171,10 @@ def apply_contact_labels_to_motion(
 
     # Load contact labels
     contact_data = np.load(contact_labels_path, allow_pickle=True)
+    contact_input_fps = fps_from_mapping(contact_data, input_fps)
     foot_contacts = contact_data["foot_contacts"]  # [K, 2] - left, right
 
-    factor = input_fps // output_fps
+    factor = downsample_factor(contact_input_fps, output_fps)
     if factor > 1:
         foot_contacts = foot_contacts[::factor]
 
@@ -200,7 +209,9 @@ def main(
         ..., help="Directory to save ProtoMotions motion files."
     ),
     input_fps: int = typer.Option(30, help="Input motion fps"),
-    output_fps: int = typer.Option(30, help="Output motion fps"),
+    output_fps: Optional[int] = typer.Option(
+        None, help="Output motion fps. Defaults to each retargeted motion's input fps."
+    ),
     force_remake: bool = False,
     ignore_first_n_frames: int = 0,  # ignore the first n frames of the motion
     # Motion filter options
@@ -265,11 +276,6 @@ def main(
     print(f"Left foot: {left_foot_name} (index {left_foot_idx})")
     print(f"Right foot: {right_foot_name} (index {right_foot_idx})")
 
-    if input_fps % output_fps != 0:
-        raise ValueError(
-            f"input_fps ({input_fps}) must be divisible by output_fps ({output_fps})"
-        )
-
     # Find both NPZ and CSV files
     npz_files = sorted(list(glob.glob(str(retargeted_motion_dir / "*.npz"))))
     csv_files = sorted(list(glob.glob(str(retargeted_motion_dir / "*.csv"))))
@@ -291,11 +297,11 @@ def main(
         try:
             # Determine file type and process accordingly
             if motion_file.suffix.lower() == ".csv":
-                root_pos, root_rot_wxyz, joint_angles = process_csv_file(
+                root_pos, root_rot_wxyz, joint_angles, motion_fps = process_csv_file(
                     motion_file_path, input_fps, output_fps, device, dtype
                 )
             elif motion_file.suffix.lower() == ".npz":
-                root_pos, root_rot_wxyz, joint_angles = process_npz_file(
+                root_pos, root_rot_wxyz, joint_angles, motion_fps = process_npz_file(
                     motion_file_path, input_fps, output_fps, device, dtype
                 )
             else:
@@ -317,7 +323,7 @@ def main(
                 kinematic_info=kinematic_info,
                 root_pos=root_pos_from_qpos,
                 joint_rot_mats=joint_rot_mats,
-                fps=output_fps,
+                fps=motion_fps,
                 compute_velocities=True,
                 velocity_max_horizon=3,  # Use multi-horizon minimum for noise-filtered velocities
             )
@@ -342,7 +348,7 @@ def main(
 
             dof_vel = compute_cartesian_velocity(
                 batched_robot_pos=joint_angles.unsqueeze(1),
-                fps=output_fps,
+                fps=motion_fps,
             )
             motion.dof_vel = dof_vel.squeeze(1)
 
@@ -368,7 +374,7 @@ def main(
                     contact_labels_dir=contact_labels_dir,
                     motion_filename=motion_file.name,
                     input_fps=input_fps,
-                    output_fps=output_fps,
+                    output_fps=motion_fps,
                     left_foot_idx=left_foot_idx,
                     right_foot_idx=right_foot_idx,
                     device=device,

--- a/data/scripts/extract_retargeting_input_keypoints_from_packaged_motionlib.py
+++ b/data/scripts/extract_retargeting_input_keypoints_from_packaged_motionlib.py
@@ -100,6 +100,7 @@ from keypoint_utils import (
     get_keypoint_indices,
     get_mjcf_path,
 )
+from protomotions.utils.retargeting_fps import fps_from_motion_dt
 
 app = typer.Typer(pretty_exceptions_enable=False)
 
@@ -204,6 +205,7 @@ def main(
 
         try:
             num_frames = motion_lib.motion_num_frames[motion_idx].item()
+            motion_fps = fps_from_motion_dt(motion_lib.motion_dt[motion_idx].item())
             start_frame = motion_lib.length_starts[motion_idx].item()
             end_frame = start_frame + num_frames
 
@@ -252,6 +254,7 @@ def main(
                 "orientations": keypoint_data["orientations"].cpu().numpy(),
                 "left_foot_contacts": keypoint_data["left_foot_contacts"],
                 "right_foot_contacts": keypoint_data["right_foot_contacts"],
+                "fps": motion_fps,
             }
             print(
                 f"keypoint_positions.shape: {keypoint_data_to_save['positions'].shape}"

--- a/protomotions/tests/test_retargeting_fps_metadata.py
+++ b/protomotions/tests/test_retargeting_fps_metadata.py
@@ -1,0 +1,104 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+
+def _load_converter(monkeypatch):
+    repo_root = Path(__file__).resolve().parents[2]
+    scripts_dir = repo_root / "data" / "scripts"
+    monkeypatch.syspath_prepend(str(scripts_dir))
+
+    pose_lib = types.ModuleType("protomotions.components.pose_lib")
+    for name in [
+        "extract_kinematic_info",
+        "fk_from_transforms_with_velocities",
+        "compute_cartesian_velocity",
+        "extract_transforms_from_qpos",
+        "extract_qpos_from_transforms",
+    ]:
+        setattr(pose_lib, name, lambda *args, **kwargs: None)
+    monkeypatch.setitem(sys.modules, "protomotions.components.pose_lib", pose_lib)
+
+    factory = types.ModuleType("protomotions.robot_configs.factory")
+    factory.robot_config = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "protomotions.robot_configs.factory", factory)
+
+    motion_filter = types.ModuleType("motion_filter")
+    motion_filter.passes_exclude_motion_filter = lambda *args, **kwargs: True
+    monkeypatch.setitem(sys.modules, "motion_filter", motion_filter)
+
+    module_path = scripts_dir / "convert_pyroki_retargeted_robot_motions_to_proto.py"
+    spec = importlib.util.spec_from_file_location("retargeted_converter", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_retargeted_npz(path: Path, fps: float) -> None:
+    np.savez_compressed(
+        path,
+        base_frame_pos=np.arange(18, dtype=np.float32).reshape(6, 3),
+        base_frame_wxyz=np.tile(
+            np.array([[1.0, 0.0, 0.0, 0.0]], dtype=np.float32), (6, 1)
+        ),
+        joint_angles=np.arange(12, dtype=np.float32).reshape(6, 2),
+        fps=np.array(fps, dtype=np.float32),
+    )
+
+
+def test_process_npz_file_uses_embedded_fps_by_default(tmp_path, monkeypatch):
+    converter = _load_converter(monkeypatch)
+    npz_path = tmp_path / "motion_retargeted.npz"
+    _write_retargeted_npz(npz_path, fps=50.0)
+
+    root_pos, root_rot_wxyz, joint_angles, motion_fps = converter.process_npz_file(
+        npz_path,
+        input_fps=30,
+        output_fps=None,
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+    )
+
+    assert motion_fps == pytest.approx(50.0)
+    assert root_pos.shape == (6, 3)
+    assert root_rot_wxyz.shape == (6, 4)
+    assert joint_angles.shape == (6, 2)
+
+
+def test_process_npz_file_downsamples_from_embedded_fps(tmp_path, monkeypatch):
+    converter = _load_converter(monkeypatch)
+    npz_path = tmp_path / "motion_retargeted.npz"
+    _write_retargeted_npz(npz_path, fps=50.0)
+
+    root_pos, _, _, motion_fps = converter.process_npz_file(
+        npz_path,
+        input_fps=30,
+        output_fps=25,
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+    )
+
+    assert motion_fps == pytest.approx(25.0)
+    assert root_pos.shape == (3, 3)
+    assert root_pos[:, 0].tolist() == [0.0, 6.0, 12.0]
+
+
+def test_process_npz_file_rejects_inexact_fps_downsample(tmp_path, monkeypatch):
+    converter = _load_converter(monkeypatch)
+    npz_path = tmp_path / "motion_retargeted.npz"
+    _write_retargeted_npz(npz_path, fps=50.0)
+
+    with pytest.raises(ValueError, match="integer multiple"):
+        converter.process_npz_file(
+            npz_path,
+            input_fps=30,
+            output_fps=30,
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+        )

--- a/protomotions/utils/retargeting_fps.py
+++ b/protomotions/utils/retargeting_fps.py
@@ -1,0 +1,45 @@
+"""FPS metadata helpers for retargeting pipelines."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def fps_from_mapping(mapping, fallback_fps: float, key: str = "fps") -> float:
+    """Read scalar FPS metadata from a numpy-style mapping."""
+    if key not in mapping:
+        return float(fallback_fps)
+    return float(np.asarray(mapping[key]).item())
+
+
+def fps_from_motion_dt(motion_dt) -> float:
+    """Convert MotionLib dt metadata to FPS."""
+    return 1.0 / float(np.asarray(motion_dt).item())
+
+
+def subsampled_fps(source_fps: float, subsample_factor: int) -> float:
+    """Return the FPS after keeping every Nth frame."""
+    if subsample_factor <= 0:
+        raise ValueError("subsample_factor must be positive")
+    return float(source_fps) / int(subsample_factor)
+
+
+def resolve_output_fps(input_fps: float, requested_output_fps: float | None) -> float:
+    """Default output FPS to the per-motion input FPS."""
+    if requested_output_fps is None:
+        return float(input_fps)
+    return float(requested_output_fps)
+
+
+def downsample_factor(input_fps: float, output_fps: float) -> int:
+    """Return integer frame stride for exact FPS downsampling."""
+    input_fps = float(input_fps)
+    output_fps = float(output_fps)
+    ratio = input_fps / output_fps
+    factor = int(round(ratio))
+    if factor < 1 or not np.isclose(ratio, factor, rtol=1e-6, atol=1e-8):
+        raise ValueError(
+            f"input_fps ({input_fps:g}) must be an integer multiple of "
+            f"output_fps ({output_fps:g})"
+        )
+    return factor

--- a/pyroki/batch_retarget_to_g1_from_keypoints.py
+++ b/pyroki/batch_retarget_to_g1_from_keypoints.py
@@ -19,6 +19,7 @@ import glob
 import os
 import argparse
 from pathlib import Path
+import sys
 
 import jax
 import jax.numpy as jnp
@@ -28,6 +29,12 @@ import jaxls
 import numpy as onp
 import pyroki as pk
 import yourdfpy
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from protomotions.utils.retargeting_fps import fps_from_mapping, subsampled_fps
 
 G1_LINK_NAMES = None
 N_retarget = 15
@@ -86,7 +93,13 @@ def get_humanoid_retarget_indices() -> jnp.ndarray:
 human_retarget_names, g1_joint_retarget_indices = None, None
 
 
-def load_motion_data(motion_path, source_type, subsample_factor, target_raw_frames):
+def load_motion_data(
+    motion_path,
+    source_type,
+    subsample_factor,
+    target_raw_frames,
+    fallback_input_fps=30.0,
+):
     """Load and process motion data from a keypoints file.
 
     Args:
@@ -94,12 +107,14 @@ def load_motion_data(motion_path, source_type, subsample_factor, target_raw_fram
         source_type: Source type ('smpl' or 'rigv1')
         subsample_factor: Subsampling factor
         target_raw_frames: Target number of raw frames before subsampling
+        fallback_input_fps: FPS to use for legacy keypoint files without metadata
 
     Returns:
-        Tuple of (simplified_keypoints, keypoint_orientations, left_foot_contact, right_foot_contact, num_timesteps)
+        Tuple of (simplified_keypoints, keypoint_orientations, left_foot_contact, right_foot_contact, num_timesteps, input_fps)
     """
     print(f"Loading motion from: {motion_path}")
     motion_data = onp.load(motion_path, allow_pickle=True).item()
+    input_fps = fps_from_mapping(motion_data, fallback_input_fps)
 
     # Compute target subsampled frames from raw frames and subsample factor
     target_subsampled_frames = len(list(range(0, target_raw_frames, subsample_factor)))
@@ -292,11 +307,18 @@ def load_motion_data(motion_path, source_type, subsample_factor, target_raw_fram
         left_foot_contact,
         right_foot_contact,
         num_timesteps,
+        input_fps,
     )
 
 
 def save_contact_labels(
-    output_path, left_foot_contact, right_foot_contact, num_timesteps
+    output_path,
+    left_foot_contact,
+    right_foot_contact,
+    num_timesteps,
+    fps,
+    source_fps,
+    subsample_factor,
 ):
     """Save processed foot contact labels to disk.
 
@@ -305,6 +327,9 @@ def save_contact_labels(
         left_foot_contact: Left foot contact array [T, 1]
         right_foot_contact: Right foot contact array [T, 1]
         num_timesteps: Number of actual timesteps (to trim padding)
+        fps: FPS of the saved contact labels after subsampling
+        source_fps: FPS of the source keypoint data before subsampling
+        subsample_factor: Frame stride used for retargeting input
     """
     # Extract contact labels (already smoothed from load_motion_data), trim to actual length
     left_contacts = left_foot_contact[:num_timesteps].squeeze(-1)  # [K]
@@ -314,7 +339,13 @@ def save_contact_labels(
     foot_contacts = onp.stack([left_contacts, right_contacts], axis=-1)  # [K, 2]
 
     # Save contact labels
-    onp.savez_compressed(output_path, foot_contacts=foot_contacts)
+    onp.savez_compressed(
+        output_path,
+        foot_contacts=foot_contacts,
+        fps=fps,
+        source_fps=source_fps,
+        subsample_factor=subsample_factor,
+    )
     print(f"Saved contact labels to {output_path} with shape {foot_contacts.shape}")
 
 
@@ -463,13 +494,23 @@ def main():
                 print(f"Output file {output_filename} already exists, skipping...")
                 continue
 
-            _, _, left_foot_contact, right_foot_contact, num_timesteps = (
+            _, _, left_foot_contact, right_foot_contact, num_timesteps, input_fps = (
                 load_motion_data(
-                    motion_path, args.source_type, subsample_factor, TARGET_RAW_FRAMES
+                    motion_path,
+                    args.source_type,
+                    subsample_factor,
+                    TARGET_RAW_FRAMES,
+                    args.input_fps,
                 )
             )
             save_contact_labels(
-                output_path, left_foot_contact, right_foot_contact, num_timesteps
+                output_path,
+                left_foot_contact,
+                right_foot_contact,
+                num_timesteps,
+                subsampled_fps(input_fps, subsample_factor),
+                input_fps,
+                subsample_factor,
             )
         return
 
@@ -529,11 +570,13 @@ def main():
             left_foot_contact,
             right_foot_contact,
             num_timesteps,
+            input_fps,
         ) = load_motion_data(
             test_keypoints_paths[current_motion_index],
             args.source_type,
             subsample_factor,
             TARGET_RAW_FRAMES,
+            args.input_fps,
         )
         server = viser.ViserServer()
         base_frame = server.scene.add_frame("/base", show_axes=False)
@@ -572,7 +615,7 @@ def main():
                 g1_retarget_mask=g1_retarget_mask,
                 weights=weights.get_weights(),  # type: ignore
                 subsample_factor=subsample_factor,
-                input_fps=args.input_fps,
+                input_fps=input_fps,
             )
             gen_button.disabled = False
             retarget_next_button.disabled = False  # Re-enable after generating
@@ -581,7 +624,8 @@ def main():
         gen_button.on_click(lambda _: generate_trajectory())
 
         def retarget_next_motion(_: viser.GuiEvent):
-            nonlocal current_motion_index, Ts_world_root, joints, num_timesteps
+            nonlocal current_motion_index, Ts_world_root, joints
+            nonlocal num_timesteps, input_fps
             nonlocal \
                 simplified_keypoints, \
                 keypoint_orientations, \
@@ -596,11 +640,13 @@ def main():
                 left_foot_contact,
                 right_foot_contact,
                 num_timesteps,
+                input_fps,
             ) = load_motion_data(
                 test_keypoints_paths[current_motion_index],
                 args.source_type,
                 subsample_factor,
                 TARGET_RAW_FRAMES,
+                args.input_fps,
             )
 
             # Update UI elements that depend on num_timesteps (displayable frames)
@@ -641,7 +687,7 @@ def main():
             except Exception as _:
                 pass
 
-            time.sleep(subsample_factor / args.input_fps)
+            time.sleep(subsample_factor / input_fps)
     else:
         print(
             "Running in non-visualize mode. Retargeting all motions and saving to disk."
@@ -670,8 +716,13 @@ def main():
                 left_foot_contact,
                 right_foot_contact,
                 num_timesteps,
+                input_fps,
             ) = load_motion_data(
-                motion_path, args.source_type, subsample_factor, TARGET_RAW_FRAMES
+                motion_path,
+                args.source_type,
+                subsample_factor,
+                TARGET_RAW_FRAMES,
+                args.input_fps,
             )
 
             Ts_world_root, joints = solve_retargeting(
@@ -685,7 +736,7 @@ def main():
                 g1_retarget_mask=g1_retarget_mask,
                 weights=weights_dict,
                 subsample_factor=subsample_factor,
-                input_fps=args.input_fps,
+                input_fps=input_fps,
             )
 
             # Save results, sliced to the actual motion length
@@ -695,6 +746,9 @@ def main():
                     Ts_world_root.wxyz_xyz[:num_timesteps, :4]
                 ),
                 "joint_angles": onp.array(joints[:num_timesteps]),
+                "fps": subsampled_fps(input_fps, subsample_factor),
+                "source_fps": input_fps,
+                "subsample_factor": subsample_factor,
             }
 
             onp.savez_compressed(output_path, **results_to_save)

--- a/pyroki/batch_retarget_to_h1_2_from_keypoints.py
+++ b/pyroki/batch_retarget_to_h1_2_from_keypoints.py
@@ -19,6 +19,7 @@ import glob
 import os
 import argparse
 from pathlib import Path
+import sys
 
 import jax
 import jax.numpy as jnp
@@ -28,6 +29,12 @@ import jaxls
 import numpy as onp
 import pyroki as pk
 import yourdfpy
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from protomotions.utils.retargeting_fps import fps_from_mapping, subsampled_fps
 
 H1_2_LINK_NAMES = None
 N_retarget = 15
@@ -83,7 +90,13 @@ def get_humanoid_retarget_indices() -> jnp.ndarray:
 human_retarget_names, h1_2_joint_retarget_indices = None, None
 
 
-def load_motion_data(motion_path, source_type, subsample_factor, target_raw_frames):
+def load_motion_data(
+    motion_path,
+    source_type,
+    subsample_factor,
+    target_raw_frames,
+    fallback_input_fps=30.0,
+):
     """Load and process motion data from a keypoints file.
 
     Args:
@@ -91,12 +104,14 @@ def load_motion_data(motion_path, source_type, subsample_factor, target_raw_fram
         source_type: Source type ('smpl' or 'rigv1')
         subsample_factor: Subsampling factor
         target_raw_frames: Target number of raw frames before subsampling
+        fallback_input_fps: FPS to use for legacy keypoint files without metadata
 
     Returns:
-        Tuple of (simplified_keypoints, keypoint_orientations, left_foot_contact, right_foot_contact, num_timesteps)
+        Tuple of (simplified_keypoints, keypoint_orientations, left_foot_contact, right_foot_contact, num_timesteps, input_fps)
     """
     print(f"Loading motion from: {motion_path}")
     motion_data = onp.load(motion_path, allow_pickle=True).item()
+    input_fps = fps_from_mapping(motion_data, fallback_input_fps)
 
     # Compute target subsampled frames from raw frames and subsample factor
     target_subsampled_frames = len(list(range(0, target_raw_frames, subsample_factor)))
@@ -289,11 +304,18 @@ def load_motion_data(motion_path, source_type, subsample_factor, target_raw_fram
         left_foot_contact,
         right_foot_contact,
         num_timesteps,
+        input_fps,
     )
 
 
 def save_contact_labels(
-    output_path, left_foot_contact, right_foot_contact, num_timesteps
+    output_path,
+    left_foot_contact,
+    right_foot_contact,
+    num_timesteps,
+    fps,
+    source_fps,
+    subsample_factor,
 ):
     """Save processed foot contact labels to disk.
 
@@ -302,6 +324,9 @@ def save_contact_labels(
         left_foot_contact: Left foot contact array [T, 1]
         right_foot_contact: Right foot contact array [T, 1]
         num_timesteps: Number of actual timesteps (to trim padding)
+        fps: FPS of the saved contact labels after subsampling
+        source_fps: FPS of the source keypoint data before subsampling
+        subsample_factor: Frame stride used for retargeting input
     """
     # Extract contact labels (already smoothed from load_motion_data), trim to actual length
     left_contacts = left_foot_contact[:num_timesteps].squeeze(-1)  # [K]
@@ -311,7 +336,13 @@ def save_contact_labels(
     foot_contacts = onp.stack([left_contacts, right_contacts], axis=-1)  # [K, 2]
 
     # Save contact labels
-    onp.savez_compressed(output_path, foot_contacts=foot_contacts)
+    onp.savez_compressed(
+        output_path,
+        foot_contacts=foot_contacts,
+        fps=fps,
+        source_fps=source_fps,
+        subsample_factor=subsample_factor,
+    )
     print(f"Saved contact labels to {output_path} with shape {foot_contacts.shape}")
 
 
@@ -460,13 +491,23 @@ def main():
                 print(f"Output file {output_filename} already exists, skipping...")
                 continue
 
-            _, _, left_foot_contact, right_foot_contact, num_timesteps = (
+            _, _, left_foot_contact, right_foot_contact, num_timesteps, input_fps = (
                 load_motion_data(
-                    motion_path, args.source_type, subsample_factor, TARGET_RAW_FRAMES
+                    motion_path,
+                    args.source_type,
+                    subsample_factor,
+                    TARGET_RAW_FRAMES,
+                    args.input_fps,
                 )
             )
             save_contact_labels(
-                output_path, left_foot_contact, right_foot_contact, num_timesteps
+                output_path,
+                left_foot_contact,
+                right_foot_contact,
+                num_timesteps,
+                subsampled_fps(input_fps, subsample_factor),
+                input_fps,
+                subsample_factor,
             )
         return
 
@@ -526,11 +567,13 @@ def main():
             left_foot_contact,
             right_foot_contact,
             num_timesteps,
+            input_fps,
         ) = load_motion_data(
             test_keypoints_paths[current_motion_index],
             args.source_type,
             subsample_factor,
             TARGET_RAW_FRAMES,
+            args.input_fps,
         )
         server = viser.ViserServer()
         base_frame = server.scene.add_frame("/base", show_axes=False)
@@ -569,7 +612,7 @@ def main():
                 h1_2_retarget_mask=h1_2_retarget_mask,
                 weights=weights.get_weights(),  # type: ignore
                 subsample_factor=subsample_factor,
-                input_fps=args.input_fps,
+                input_fps=input_fps,
             )
             gen_button.disabled = False
             retarget_next_button.disabled = False  # Re-enable after generating
@@ -578,7 +621,8 @@ def main():
         gen_button.on_click(lambda _: generate_trajectory())
 
         def retarget_next_motion(_: viser.GuiEvent):
-            nonlocal current_motion_index, Ts_world_root, joints, num_timesteps
+            nonlocal current_motion_index, Ts_world_root, joints
+            nonlocal num_timesteps, input_fps
             nonlocal \
                 simplified_keypoints, \
                 keypoint_orientations, \
@@ -593,11 +637,13 @@ def main():
                 left_foot_contact,
                 right_foot_contact,
                 num_timesteps,
+                input_fps,
             ) = load_motion_data(
                 test_keypoints_paths[current_motion_index],
                 args.source_type,
                 subsample_factor,
                 TARGET_RAW_FRAMES,
+                args.input_fps,
             )
 
             # Update UI elements that depend on num_timesteps (displayable frames)
@@ -638,7 +684,7 @@ def main():
             except Exception as _:
                 pass
 
-            time.sleep(subsample_factor / args.input_fps)
+            time.sleep(subsample_factor / input_fps)
     else:
         print(
             "Running in non-visualize mode. Retargeting all motions and saving to disk."
@@ -667,8 +713,13 @@ def main():
                 left_foot_contact,
                 right_foot_contact,
                 num_timesteps,
+                input_fps,
             ) = load_motion_data(
-                motion_path, args.source_type, subsample_factor, TARGET_RAW_FRAMES
+                motion_path,
+                args.source_type,
+                subsample_factor,
+                TARGET_RAW_FRAMES,
+                args.input_fps,
             )
 
             Ts_world_root, joints = solve_retargeting(
@@ -682,7 +733,7 @@ def main():
                 h1_2_retarget_mask=h1_2_retarget_mask,
                 weights=weights_dict,
                 subsample_factor=subsample_factor,
-                input_fps=args.input_fps,
+                input_fps=input_fps,
             )
 
             # Save results, sliced to the actual motion length
@@ -692,6 +743,9 @@ def main():
                     Ts_world_root.wxyz_xyz[:num_timesteps, :4]
                 ),
                 "joint_angles": onp.array(joints[:num_timesteps]),
+                "fps": subsampled_fps(input_fps, subsample_factor),
+                "source_fps": input_fps,
+                "subsample_factor": subsample_factor,
             }
 
             onp.savez_compressed(output_path, **results_to_save)


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                  

Fixes the retargeting pipeline so motions keep the actual FPS produced by the initial `.motion` conversion instead of falling back to 30 FPS later in the flow.

The AMASS-to-`.motion` conversion may produce an FPS above 30 when 30 is not an exact divisor of the source FPS, e.g. 100 FPS input becomes 50 FPS. Retargeting now preserves that resolved FPS.

## Changes                                                                                                                                                                                                                                                                                                  

- Save per-motion FPS metadata when extracting retargeting keypoints from packaged MotionLib files.
- Use keypoint FPS metadata in G1 and H1_2 Pyroki retargeting instead of assuming `--input-fps 30`.
- Save FPS metadata in retargeted `.npz` outputs and contact label files.
- Read retargeted `.npz` FPS metadata when converting retargeted motions back to ProtoMotions `.motion`.
- Add regression tests covering embedded FPS metadata and exact downsampling behavior.