### PR TITLE
Clean up PR 232: Newton Python 3 fix and fatal diagnostics

### DIFF
--- a/protomotions/simulator/newton/simulator.py
+++ b/protomotions/simulator/newton/simulator.py
@@ -367,7 +367,7 @@ class NewtonSimulator(Simulator):
         self.robot_view = ArticulationView(
             self.model,
             pattern="robot",
-            include_joints=self._newton_dof_names.keys(),
+            include_joints=list(self._newton_dof_names.keys()),
             include_links=self._body_names,
         )
 

--- a/protomotions/tests/test_newton_python3_compat.py
+++ b/protomotions/tests/test_newton_python3_compat.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import ast
+from pathlib import Path
+
+
+NEWTON_SIMULATOR = (
+    Path(__file__).resolve().parents[1] / "simulator" / "newton" / "simulator.py"
+)
+
+
+def test_newton_articulation_view_receives_joint_name_sequence():
+    tree = ast.parse(NEWTON_SIMULATOR.read_text(), filename=str(NEWTON_SIMULATOR))
+    include_joints_values = [
+        keyword.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "ArticulationView"
+        for keyword in node.keywords
+        if keyword.arg == "include_joints"
+    ]
+
+    assert len(include_joints_values) == 1
+    value = include_joints_values[0]
+    assert isinstance(value, ast.Call)
+    assert isinstance(value.func, ast.Name)
+    assert value.func.id == "list"

--- a/protomotions/train_agent.py
+++ b/protomotions/train_agent.py
@@ -290,6 +290,10 @@ def create_parser():
 
 # Parse arguments first (argparse is safe, doesn't import torch)
 import argparse  # noqa: E402
+import faulthandler  # noqa: E402
+
+faulthandler.enable()
+
 from protomotions.utils.cli_utils import parse_bool  # noqa: E402
 
 parser = create_parser()
@@ -304,6 +308,9 @@ AppLauncher = import_simulator_before_torch(args.simulator)
 # Now safe to import everything else including torch
 from pathlib import Path  # noqa: E402
 import logging  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s: %(message)s")
+
 from protomotions.utils.hydra_replacement import get_class  # noqa: E402
 import importlib.util  # noqa: E402
 import shutil  # noqa: E402


### PR DESCRIPTION
Follow-up to #232.

Credit: this work builds directly on the original fixes and investigation contributed by @alexhegit in PR #232. Thank you for identifying the Python 3 Newton issue and the need for better fatal-crash diagnostics.

This follow-up keeps the substantive fixes while removing leftover debug instrumentation:

- Convert the Newton `dict_keys` view to a list before passing it to `ArticulationView`.
- Enable Python's standard-library `faulthandler` in `train_agent.py` for native simulator/CUDA crash diagnostics.
- Configure training logs consistently with `inference_agent.py`.
- Remove debug prints and duplicate imports from the proposed implementation.
- Add a focused regression test for the Newton Python 3 compatibility fix.

Verification:
- Newton uv environment smoke test initialized the G1 simulator and executed the FK path using Warp 1.12.1, Newton, and Torch CUDA 12.8.
- Newton's `match_labels` rejects the old `dict_keys` value with `TypeError` and accepts the list form.
- Focused regression test: 1 passed.
- Train/SLURM tests: 21 passed.
- `py_compile`: passed.
- `git diff --check`: passed.

The FK harness reports a pre-existing 0.000012 m tolerance-edge body-position discrepancy, but the Newton process initializes and runs successfully. No new dependencies are introduced.