### PR TITLE
docs: correct BONES-SEED G1 DOF count

### DIFF
--- a/docs/source/getting_started/kimodo_preparation.rst
+++ b/docs/source/getting_started/kimodo_preparation.rst
@@ -234,7 +234,7 @@ Supported Skeleton Formats
      - ``soma23``
    * - BONES-SEED G1 CSV
      - ``.csv``
-     - 23 DOFs
+     - 29 DOFs
      - ``convert_g1_csv_to_proto.py``
      - ``g1``
 


### PR DESCRIPTION
The merged ARDY/Kimodo documentation correctly uses 29 DOFs for generator-native G1 CSVs, but the BONES-SEED G1 CSV row still says 23. NVIDIA's GR00T Whole-Body Control documentation identifies the BONES-SEED G1 retargets as 29 DOF, matching ProtoMotions' g1_bm_box_feet.xml converter contract. This changes only that stale table entry from 23 to 29.