### PR TITLE
Fix device mismatch in Newton friction domain randomization on GPU

### DIFF
--- a/protomotions/simulator/newton/randomization_utils.py
+++ b/protomotions/simulator/newton/randomization_utils.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any, Dict
+
+import torch
+
+
+def move_friction_tables_to_device(
+    friction_dr: Dict[str, Any], device: torch.device
+) -> Dict[str, Any]:
+    """Return the friction domain-randomization dict with bucket tables on ``device``.
+
+    The base simulator samples the friction bucket tables on CPU because
+    IsaacGym and IsaacLab consume them there. Newton indexes the tables with
+    bucket ids on the simulation device, so on GPU the tables must be moved
+    first or advanced indexing raises a device-mismatch RuntimeError.
+    """
+    moved = dict(friction_dr)
+    for key in ("static_friction", "dynamic_friction", "restitution"):
+        table = moved.get(key)
+        if table is not None:
+            moved[key] = table.to(device)
+    return moved

--- a/protomotions/simulator/newton/simulator.py
+++ b/protomotions/simulator/newton/simulator.py
@@ -27,6 +27,9 @@ from protomotions.simulator.newton.contact_utils import (
     get_contact_sensor_body_patterns,
     validate_contact_sensor_match,
 )
+from protomotions.simulator.newton.randomization_utils import (
+    move_friction_tables_to_device,
+)
 import warp as wp
 import newton
 from newton import JointTargetMode
@@ -528,10 +531,15 @@ class NewtonSimulator(Simulator):
             current_friction = wp.to_torch(mu_wp)
             current_restitution = wp.to_torch(rest_wp)
 
-            # Get body indices that should be randomized
-            body_indices = self._domain_randomization["friction"]["body_indices"]
-            static_friction = self._domain_randomization["friction"]["static_friction"]
-            restitution = self._domain_randomization["friction"]["restitution"]
+            # Get body indices that should be randomized. The bucket tables are
+            # sampled on CPU by the base simulator; move them to the simulation
+            # device so they can be indexed with on-device bucket ids below.
+            friction_dr = move_friction_tables_to_device(
+                self._domain_randomization["friction"], current_friction.device
+            )
+            body_indices = friction_dr["body_indices"]
+            static_friction = friction_dr["static_friction"]
+            restitution = friction_dr["restitution"]
 
             num_buckets = static_friction.shape[0] if static_friction is not None else 0
 

--- a/protomotions/tests/test_newton_domain_randomization.py
+++ b/protomotions/tests/test_newton_domain_randomization.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from protomotions.simulator.newton.randomization_utils import (
+    move_friction_tables_to_device,
+)
+
+
+def _cpu_friction_dr(num_buckets: int = 4, num_bodies: int = 2) -> dict:
+    """Friction DR dict as produced by Simulator._process_friction_domain_randomization,
+    whose bucket tables are always sampled on CPU."""
+    return {
+        "body_indices": [0, 1],
+        "static_friction": torch.rand(num_buckets, num_bodies),
+        "dynamic_friction": None,
+        "restitution": torch.rand(num_buckets, num_bodies),
+    }
+
+
+def test_move_friction_tables_preserves_values_and_none_entries():
+    friction_dr = _cpu_friction_dr()
+
+    moved = move_friction_tables_to_device(friction_dr, torch.device("cpu"))
+
+    assert moved["body_indices"] == friction_dr["body_indices"]
+    assert moved["dynamic_friction"] is None
+    assert torch.equal(moved["static_friction"], friction_dr["static_friction"])
+    assert torch.equal(moved["restitution"], friction_dr["restitution"])
+    # The input dict must not be mutated: other simulators share it and expect
+    # the tables to stay on CPU.
+    assert friction_dr["static_friction"].device.type == "cpu"
+    assert friction_dr["restitution"].device.type == "cpu"
+
+
+def test_moved_tables_support_bucket_indexing_on_target_device():
+    friction_dr = _cpu_friction_dr(num_buckets=4, num_bodies=2)
+    device = torch.device("cpu")
+
+    moved = move_friction_tables_to_device(friction_dr, device)
+    bucket_ids = torch.randint(0, 4, (8,), device=device)
+
+    values = moved["static_friction"][bucket_ids, 1]
+    assert values.shape == (8,)
+    assert values.device == moved["static_friction"].device
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_cuda_bucket_indexing_after_move():
+    """Regression test: the Newton simulator indexes the CPU-sampled bucket
+    tables with CUDA bucket ids, which raises a device-mismatch RuntimeError
+    unless the tables are moved to the simulation device first."""
+    friction_dr = _cpu_friction_dr(num_buckets=4, num_bodies=2)
+    device = torch.device("cuda")
+    bucket_ids = torch.randint(0, 4, (8,), device=device)
+
+    with pytest.raises(RuntimeError):
+        friction_dr["static_friction"][bucket_ids, 0]
+
+    moved = move_friction_tables_to_device(friction_dr, device)
+    for key in ("static_friction", "restitution"):
+        assert moved[key].device.type == "cuda"
+        values = moved[key][bucket_ids, 0]
+        assert values.device.type == "cuda"


### PR DESCRIPTION
Running `--simulator newton` on GPU with friction domain randomization fails with:

```
RuntimeError: indices should be either on cpu or on the same device as the indexed tensor (cpu)
```

The base simulator samples the friction bucket tables on CPU (`torch.rand` with no device argument in `_process_friction_domain_randomization`), but the Newton simulator's `_apply_domain_randomization_if_needed` indexes them with `bucket_ids` created on `self.device` (`static_friction[bucket_ids, idx]`).

## Fix

Move the bucket tables to the simulation device in the Newton path before indexing, mirroring the existing `.to(current_com.device)` handling for center-of-mass randomization in the same method.

The tables intentionally stay on CPU in the base simulator: IsaacLab indexes them with CPU bucket ids and writes into PhysX material buffers that live on CPU, and IsaacGym reads them via `.item()` — so sampling them on `self.device` would fix Newton but break the IsaacLab path on GPU. The helper returns a shallow copy so the shared DR dict is not mutated.

The helper lives in a new `randomization_utils.py` module (same pattern as `contact_utils.py`) because `newton/simulator.py` imports `warp`/`newton` at module top and cannot be imported in CPU-only test environments.

## Tests

New `protomotions/tests/test_newton_domain_randomization.py`:
- values, `None` entries, and `body_indices` are preserved, and the input dict is not mutated
- moved tables support bucket indexing on the target device
- CUDA regression test reproducing the original failure (skipped when CUDA is unavailable): indexing the CPU-sampled table with CUDA bucket ids raises, indexing the moved table succeeds