### PR TITLE
Fix evaluation env-parking permanently corrupting parked envs on Newton

### DIFF
--- a/protomotions/simulator/newton/simulator.py
+++ b/protomotions/simulator/newton/simulator.py
@@ -932,6 +932,28 @@ class NewtonSimulator(Simulator):
 
         return contact_binary
 
+    def park_envs(
+        self,
+        env_ids: torch.Tensor,
+        hide_z: float = -50.0,
+    ) -> None:
+        """No-op on Newton: evaluation env-parking is unnecessary and harmful.
+
+        The base implementation teleports inactive envs to ``hide_z`` to keep
+        their AABBs out of PhysX's broadphase pair budget. MuJoCo-Warp has
+        fixed per-world contact buffers and no cross-env broadphase pairs, so
+        parking buys nothing here.
+
+        Worse, a parked robot free-falls with PD control still driving its
+        joints toward policy targets: energy is pumped in with no contact to
+        dissipate it, joint velocities diverge, and the resulting non-finite
+        values persist in solver warm-start memory — permanently poisoning the
+        parked envs even after their kinematic state is restored. Leaving
+        inactive envs simulating in place (exactly as they do during training)
+        is both safe and cheap.
+        """
+        return None
+
     def _get_simulator_bodies_state(
         self, env_ids: Optional[torch.Tensor] = None
     ) -> RobotState:

--- a/protomotions/tests/test_newton_park_envs.py
+++ b/protomotions/tests/test_newton_park_envs.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Newton must not park evaluation envs.
+
+Parking (teleport to z<<0) exists to relieve PhysX's broadphase pair budget.
+On Newton/MuJoCo-Warp there is no cross-env broadphase, and a parked robot
+free-falls with PD control still active: joint velocities diverge and the
+resulting non-finite values persist in solver warm-start memory, permanently
+poisoning the parked envs. NewtonSimulator therefore overrides park_envs as a
+documented no-op; these tests pin that contract.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+
+def _newton_simulator_cls():
+    pytest.importorskip("warp")
+    pytest.importorskip("newton")
+    from protomotions.simulator.newton.simulator import NewtonSimulator
+
+    return NewtonSimulator
+
+
+def test_park_envs_is_overridden():
+    from protomotions.simulator.base_simulator.simulator import Simulator
+
+    NewtonSimulator = _newton_simulator_cls()
+    assert NewtonSimulator.park_envs is not Simulator.park_envs
+
+
+def test_park_envs_touches_no_simulator_state():
+    NewtonSimulator = _newton_simulator_cls()
+    mock_sim = MagicMock()
+    env_ids = torch.arange(4)
+
+    result = NewtonSimulator.park_envs(mock_sim, env_ids)
+
+    assert result is None
+    assert mock_sim.mock_calls == []


### PR DESCRIPTION
During mimic evaluation with more envs than motions, `MimicEvaluator._park_inactive_envs` → `Simulator.park_envs` teleports the inactive envs to `z = -50`. This exists to keep parked AABBs out of **PhysX's** broadphase pair budget (`foundLostPairsCapacity`), but on the **Newton** backend it is both unnecessary and destructive:

- MuJoCo-Warp has fixed per-world contact buffers and no cross-env broadphase pairs — parking relieves nothing.
- A parked robot free-falls with PD control still driving its joints toward policy targets. Energy is pumped in with no contact to dissipate it, joint velocities diverge, and states go non-finite.
- The NaNs persist in solver warm-start memory, so the parked envs stay non-finite **even after `restore_state` resets their kinematic state post-eval** — subsequent training aborts on the `RobotState` finite-check.

**Repro**: Newton backend, mimic eval where `num_motions < num_envs` (e.g. 1477 motions, 4096 envs). All 2619 parked envs go non-finite during the sweep and remain so afterwards:

```
AssertionError: rigid_body_pos is not finite. 2539/4096 envs affected.
```

## Fix

Override `park_envs` as a documented no-op on `NewtonSimulator`. Inactive envs simply keep simulating in place, exactly as they do during training; contact capacity is already sized for all envs.