### PR TITLE
Fix Newton multi-GPU device selection

### DIFF
--- a/protomotions/simulator/newton/simulator.py
+++ b/protomotions/simulator/newton/simulator.py
@@ -133,6 +133,12 @@ class NewtonSimulator(Simulator):
 
     def _create_simulation(self) -> None:
         """Create the Newton simulation environment."""
+        # ModelBuilder.finalize() and other Newton allocations use Warp's current
+        # device when no explicit device is provided. Each distributed process has
+        # its own rank-local Torch device, so keep Warp on that same device before
+        # creating any simulation state.
+        wp.set_device(str(self.device))
+
         self._create_envs()
         self._zero_passive_forces()
         self._setup_robot()

--- a/protomotions/tests/test_newton_device_selection.py
+++ b/protomotions/tests/test_newton_device_selection.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import ast
+from pathlib import Path
+
+
+NEWTON_SIMULATOR = (
+    Path(__file__).resolve().parents[1] / "simulator" / "newton" / "simulator.py"
+)
+
+
+def test_warp_device_is_set_before_newton_simulation_allocation():
+    tree = ast.parse(NEWTON_SIMULATOR.read_text(), filename=str(NEWTON_SIMULATOR))
+    simulator_class = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "NewtonSimulator"
+    )
+    create_simulation = next(
+        node
+        for node in simulator_class.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_create_simulation"
+    )
+
+    first_statement = create_simulation.body[1]
+    assert isinstance(first_statement, ast.Expr)
+    assert isinstance(first_statement.value, ast.Call)
+
+    set_device_call = first_statement.value
+    assert isinstance(set_device_call.func, ast.Attribute)
+    assert isinstance(set_device_call.func.value, ast.Name)
+    assert set_device_call.func.value.id == "wp"
+    assert set_device_call.func.attr == "set_device"
+    assert len(set_device_call.args) == 1
+
+    device_arg = set_device_call.args[0]
+    assert isinstance(device_arg, ast.Call)
+    assert isinstance(device_arg.func, ast.Name)
+    assert device_arg.func.id == "str"
+    assert len(device_arg.args) == 1
+    torch_device = device_arg.args[0]
+    assert isinstance(torch_device, ast.Attribute)
+    assert isinstance(torch_device.value, ast.Name)
+    assert torch_device.value.id == "self"
+    assert torch_device.attr == "device"


### PR DESCRIPTION
Newton currently leaves Warp on its default `cuda:0` device even when Lightning assigns a different CUDA device to a distributed rank. That sends implicit Newton allocations to rank 0 and makes `--simulator newton --ngpu > 1` fail during setup. This sets Warp to the simulator's rank-local Torch device before Newton creates any simulation state so both runtimes stay aligned.

- [x] Select Warp's device from the Newton simulator's assigned Torch device
- [x] Apply it before `ModelBuilder.finalize()` or any other Newton allocation
- [x] Add a regression test that pins the initialization order

## Validation

- Focused CPU-testable Newton suite: 8 passed, 1 CUDA-only test skipped
- Changed-file license, lint, typo, and diff checks
